### PR TITLE
Dev octave4 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,17 +81,17 @@ matrix:
 #          packages:
 #            - lcov
 
-#    - name: "Octave Linux"
-#      os: linux
-#      dist: bionic # bionic does not support Octave 5
-#      env:
-#        - DEBUG_CI=true
-#        - BUILD_NAME="octave-linux-macos"
-#      addons:
-#        apt:
-#          packages:
-#            - octave
-#            - octave-pkg-dev
+    - name: "Octave Linux"
+      os: linux
+      dist: bionic # bionic does not support Octave 5
+      env:
+        - DEBUG_CI=true
+        - BUILD_NAME="octave-linux-macos"
+      addons:
+        apt:
+          packages:
+            - octave
+            - octave-pkg-dev
 
     - name: "Octave MacOS"
       os: osx

--- a/bindings/Octave/LinearRegression.m
+++ b/bindings/Octave/LinearRegression.m
@@ -1,13 +1,13 @@
 classdef LinearRegression < handle
     % attributes doc: https://fr.mathworks.com/help/matlab/matlab_oop/property-attributes.html
-    properties (NonCopyable, Transient, Access = protected, Hidden) 
+    properties %(NonCopyable, Transient, Access = protected, Hidden) 
         ref
     end
 
     methods
         function obj = LinearRegression(varargin)
             printf("New LinearRegression\n");
-            mLibKriging("LinearRegression::new", obj, varargin{:});
+            obj.ref = mLibKriging("LinearRegression::new", varargin{:});
         end
         
         function delete(obj, varargin)
@@ -15,16 +15,16 @@ classdef LinearRegression < handle
             % destroy the mex backend
             if ~isempty(obj.ref)
                 printf("Delete LinearRegression\n")
-                mLibKriging("LinearRegression::delete",obj, varargin{:})
+                obj.ref = mLibKriging("LinearRegression::delete", obj.ref, varargin{:})
             end
         end
         
         function fit(obj, varargin)
-            mLibKriging("LinearRegression::fit", obj, varargin{:});
+            mLibKriging("LinearRegression::fit", obj.ref, varargin{:});
         end
         
         function varargout = predict(obj, varargin)
-            [varargout{1:nargout}] = mLibKriging("LinearRegression::predict", obj, varargin{:});
+            [varargout{1:nargout}] = mLibKriging("LinearRegression::predict", obj.ref, varargin{:});
         end
         
     end

--- a/bindings/Octave/LinearRegression_binding.cpp
+++ b/bindings/Octave/LinearRegression_binding.cpp
@@ -10,9 +10,9 @@ void build(int nlhs, void** plhs, int nrhs, const void** prhs) {
   MxMapper input{"Input",
                  nrhs,
                  const_cast<mxArray**>(prhs),  // NOLINT(cppcoreguidelines-pro-type-const-cast)
-                 RequiresArg::Exactly{1}};
-  MxMapper output{"Output", nlhs, plhs, RequiresArg::Exactly{0}};
-  buildObject<LinearRegression>(input.get<0, mxArray*>("object reference"));
+                 RequiresArg::Exactly{0}};
+  MxMapper output{"Output", nlhs, plhs, RequiresArg::Exactly{1}};
+  output.set<0>(buildObject<LinearRegression>(), "new object reference");
 }
 
 void destroy(int nlhs, void** plhs, int nrhs, const void** prhs) {
@@ -20,8 +20,9 @@ void destroy(int nlhs, void** plhs, int nrhs, const void** prhs) {
                  nrhs,
                  const_cast<mxArray**>(prhs),  // NOLINT(cppcoreguidelines-pro-type-const-cast)
                  RequiresArg::Exactly{1}};
-  MxMapper output{"Output", nlhs, plhs, RequiresArg::Exactly{0}};
-  destroyObject(input.get<0, mxArray*>("object reference"));
+  MxMapper output{"Output", nlhs, plhs, RequiresArg::Exactly{1}};
+  destroyObject(input.get<0, uint64_t>("object reference"));
+  output.set<0>(EmptyObject{}, "deleted object reference");
 }
 
 void fit(int nlhs, void** plhs, int nrhs, const void** prhs) {

--- a/bindings/Octave/tests/CMakeLists.txt
+++ b/bindings/Octave/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
+add_executable(manage_test_crash manage_test_crash.c)
+
 macro(add_octave_test)
-    set(options)
+    set(options WILL_FAIL)
     set(oneValueArgs NAME FILENAME)
     # https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#test-properties
     set(multiValueArgs PROPERTIES)
@@ -19,16 +21,28 @@ macro(add_octave_test)
     endif ()
 
     # to configure command line : http://kirste.userpage.fu-berlin.de/chemnet/use/info/octave/octave_7.html
-    add_test(NAME Octave/${ARGS_NAME}
-            COMMAND ${OCTAVE_EXECUTABLE} --path ${LIBKRIGING_OCTAVE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${ARGS_FILENAME})
+    if (NOT ARGS_WILL_FAIL)
+        add_test(NAME Octave/${ARGS_NAME}
+                COMMAND ${OCTAVE_EXECUTABLE} --path ${LIBKRIGING_OCTAVE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test_wrapper.m)
+    else ()
+        # requires crash management for Octave 4 (where exit command causes 'abort')
+        add_test(NAME Octave/${ARGS_NAME}
+                COMMAND manage_test_crash ${OCTAVE_EXECUTABLE} --path ${LIBKRIGING_OCTAVE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test_wrapper.m)
+        set_tests_properties(Octave/${ARGS_NAME}
+                PROPERTIES
+                WILL_FAIL TRUE)
+    endif ()
     set_tests_properties(Octave/${ARGS_NAME}
             PROPERTIES
             WORKING_DIRECTORY ${LIBKRIGING_OCTAVE_BINARY_DIR}
+            ENVIRONMENT "TESTFILE=${CMAKE_CURRENT_SOURCE_DIR}/${ARGS_FILENAME}"
             LABELS Octave
             ${ARGS_PROPERTIES})
 endmacro()
 
+add_octave_test(NAME success FILENAME dummy_succeededtest.m)
+add_octave_test(NAME failure FILENAME dummy_failingtest.m WILL_FAIL)
 add_octave_test(NAME mLibKriging FILENAME mLibKriging_test.m)
-add_octave_test(NAME mLibKriging-BadUsage FILENAME mLibKriging_failingtest.m PROPERTIES WILL_FAIL TRUE)
+add_octave_test(NAME mLibKriging-BadUsage FILENAME mLibKriging_failingtest.m WILL_FAIL)
 add_octave_test(NAME LinearRegression-Simple FILENAME LinearRegression_simpletest.m)
 add_octave_test(NAME LinearRegression-Complete FILENAME LinearRegression_completest.m)

--- a/bindings/Octave/tests/dummy_failingtest.m
+++ b/bindings/Octave/tests/dummy_failingtest.m
@@ -1,0 +1,1 @@
+error("This is an error")

--- a/bindings/Octave/tests/dummy_succeededtest.m
+++ b/bindings/Octave/tests/dummy_succeededtest.m
@@ -1,0 +1,1 @@
+printf("Success\n")

--- a/bindings/Octave/tests/manage_test_crash.c
+++ b/bindings/Octave/tests/manage_test_crash.c
@@ -11,7 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   pid_t pid = fork();
   if (pid == -1) {
     // fork fails
@@ -21,14 +21,14 @@ int main(int argc, char **argv) {
     int status = 0;
     wait(&status);
     if (WIFSIGNALED(status))
-      return 1; // Signal-terminated
+      return 1;  // Signal-terminated
     if (WIFEXITED(status))
       return WEXITSTATUS(status);
-    return -1; // status not managed
+    return -1;  // status not managed
   } else {
     // Child - execute wrapped command
     execvp(argv[1], argv + 1);
-    exit(2); // reached only if execvp fails
+    exit(2);  // reached only if execvp fails
   }
 }
 
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 #include <tchar.h>
 #include <windows.h>
 
-void _tmain(int argc, TCHAR *argv[]) {
+void _tmain(int argc, TCHAR* argv[]) {
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
   DWORD dwWaitResult;
@@ -55,16 +55,16 @@ void _tmain(int argc, TCHAR *argv[]) {
   }
 
   // Start the child process.
-  if (!CreateProcess(NULL,    // No module name (use command line)
-                     argv[1], // Command line
-                     NULL,    // Process handle not inheritable
-                     NULL,    // Thread handle not inheritable
-                     FALSE,   // Set handle inheritance to FALSE
-                     0,       // No creation flags
-                     NULL,    // Use parent's environment block
-                     NULL,    // Use parent's starting directory
-                     &si,     // Pointer to STARTUPINFO structure
-                     &pi)     // Pointer to PROCESS_INFORMATION structure
+  if (!CreateProcess(NULL,     // No module name (use command line)
+                     argv[1],  // Command line
+                     NULL,     // Process handle not inheritable
+                     NULL,     // Thread handle not inheritable
+                     FALSE,    // Set handle inheritance to FALSE
+                     0,        // No creation flags
+                     NULL,     // Use parent's environment block
+                     NULL,     // Use parent's starting directory
+                     &si,      // Pointer to STARTUPINFO structure
+                     &pi)      // Pointer to PROCESS_INFORMATION structure
   ) {
     printf("CreateProcess failed (%d).\n", GetLastError());
     ExitProcess(2);
@@ -75,20 +75,20 @@ void _tmain(int argc, TCHAR *argv[]) {
   printf("WaitForSingleObject() returns value is 0X%.8X\n", dwWaitResult);
 
   switch (dwWaitResult) {
-  case WAIT_ABANDONED:
-    printf("Mutex object was not released by the thread that owned the mutex "
-           "object before the owning thread terminates...\n");
-    break;
-  case WAIT_OBJECT_0:
-    printf("The child thread state was signaled !\n");
-    break;
-  case WAIT_TIMEOUT:
-    printf(
-        "Time-out interval elapsed, and the child thread's state is nonsignaled.\n");
-    break;
-  case WAIT_FAILED:
-    printf("WaitForSingleObject() failed, error %u\n", GetLastError());
-    ExitProcess(0);
+    case WAIT_ABANDONED:
+      printf(
+          "Mutex object was not released by the thread that owned the mutex "
+          "object before the owning thread terminates...\n");
+      break;
+    case WAIT_OBJECT_0:
+      printf("The child thread state was signaled !\n");
+      break;
+    case WAIT_TIMEOUT:
+      printf("Time-out interval elapsed, and the child thread's state is nonsignaled.\n");
+      break;
+    case WAIT_FAILED:
+      printf("WaitForSingleObject() failed, error %u\n", GetLastError());
+      ExitProcess(0);
   }
 
   // Close process and thread handles.

--- a/bindings/Octave/tests/manage_test_crash.c
+++ b/bindings/Octave/tests/manage_test_crash.c
@@ -1,0 +1,99 @@
+/*
+ * These code is able to convert any crash code (segfault, abort...) into a standard exit code.
+ */
+
+#ifndef _MSC_VER
+// inspired from
+// https://stackoverflow.com/questions/33693486/how-can-i-use-cmake-to-test-processes-that-are-expected-to-fail-with-an-exceptio
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  pid_t pid = fork();
+  if (pid == -1) {
+    // fork fails
+    return 2;
+  } else if (pid) {
+    // Parent - wait child and interpret its result
+    int status = 0;
+    wait(&status);
+    if (WIFSIGNALED(status))
+      return 1; // Signal-terminated
+    if (WIFEXITED(status))
+      return WEXITSTATUS(status);
+    return -1; // status not managed
+  } else {
+    // Child - execute wrapped command
+    execvp(argv[1], argv + 1);
+    exit(2); // reached only if execvp fails
+  }
+}
+
+#else /* _MSC_VER */
+// inspired from
+// https://docs.microsoft.com/en-us/windows/win32/procthread/creating-processes
+
+#include <stdio.h>
+#include <tchar.h>
+#include <windows.h>
+
+void _tmain(int argc, TCHAR *argv[]) {
+  STARTUPINFO si;
+  PROCESS_INFORMATION pi;
+  DWORD dwWaitResult;
+
+  ZeroMemory(&si, sizeof(si));
+  si.cb = sizeof(si);
+  ZeroMemory(&pi, sizeof(pi));
+
+  if (argc != 2) {
+    printf("Usage: %s [cmdline]\n", argv[0]);
+    return;
+  }
+
+  // Start the child process.
+  if (!CreateProcess(NULL,    // No module name (use command line)
+                     argv[1], // Command line
+                     NULL,    // Process handle not inheritable
+                     NULL,    // Thread handle not inheritable
+                     FALSE,   // Set handle inheritance to FALSE
+                     0,       // No creation flags
+                     NULL,    // Use parent's environment block
+                     NULL,    // Use parent's starting directory
+                     &si,     // Pointer to STARTUPINFO structure
+                     &pi)     // Pointer to PROCESS_INFORMATION structure
+  ) {
+    printf("CreateProcess failed (%d).\n", GetLastError());
+    ExitProcess(2);
+  }
+
+  // Wait until child process exits.
+  dwWaitResult = WaitForSingleObject(pi.hProcess, INFINITE);
+  printf("WaitForSingleObject() returns value is 0X%.8X\n", dwWaitResult);
+
+  switch (dwWaitResult) {
+  case WAIT_ABANDONED:
+    printf("Mutex object was not released by the thread that owned the mutex "
+           "object before the owning thread terminates...\n");
+    break;
+  case WAIT_OBJECT_0:
+    printf("The child thread state was signaled !\n");
+    break;
+  case WAIT_TIMEOUT:
+    printf(
+        "Time-out interval elapsed, and the child thread's state is nonsignaled.\n");
+    break;
+  case WAIT_FAILED:
+    printf("WaitForSingleObject() failed, error %u\n", GetLastError());
+    ExitProcess(0);
+  }
+
+  // Close process and thread handles.
+  CloseHandle(pi.hProcess);
+  CloseHandle(pi.hThread);
+}
+
+#endif /* _MSC_VER */

--- a/bindings/Octave/tests/test_wrapper.m
+++ b/bindings/Octave/tests/test_wrapper.m
@@ -1,0 +1,10 @@
+filepath = getenv("TESTFILE");
+printf("Testing file '%s'\n", filepath);
+[dir,name,ext]=fileparts(filepath);
+addpath(dir)
+try
+    eval(name);
+catch exception
+    printf("An exception has been caught: %s", exception.identifier);
+    exit(1);
+end

--- a/bindings/Octave/tools/MxMapper.hpp
+++ b/bindings/Octave/tools/MxMapper.hpp
@@ -48,7 +48,7 @@ class MxMapper : public NonCopyable {
   }
 
   template <int I, typename T>
-  void set(T& t, const char* msg = nullptr) {
+  void set(const T& t, const char* msg = nullptr) {
     static_assert(I >= 0);
     if (I >= m_n) {
       throw MxException(LOCATION(), "mLibKriging:missingArg", "Unavailable parameter %s", (msg) ? msg : "");
@@ -58,7 +58,7 @@ class MxMapper : public NonCopyable {
   }
 
   template <int I, typename T>
-  void setOptional(T& t, const char* msg = nullptr) {
+  void setOptional(const T& t, const char* msg = nullptr) {
     static_assert(I >= 0);
     if (I >= m_n) {
       return;

--- a/bindings/Octave/tools/ObjectAccessor.cpp
+++ b/bindings/Octave/tools/ObjectAccessor.cpp
@@ -3,20 +3,15 @@
 #include "MxException.hpp"
 
 ObjectCollector::ref_t getObject(const mxArray* obj) {
-  mxArray* objectRef = mxGetProperty(obj, 0, "ref");
-  if (objectRef == nullptr) {
-    throw MxException(LOCATION(), "mLibKriging:badObject", "object does not contain 'ref' property");
-  }
-
-  if (mxIsEmpty(objectRef)) {
+  if (mxIsEmpty(obj)) {
     throw MxException(LOCATION(), "mLibKriging:emptyObject", "object already contain an empty 'ref' property");
   }
 
-  auto ref = *(static_cast<uint64_t*>(mxGetData(objectRef)));
+  auto ref = *(static_cast<uint64_t*>(mxGetData(obj)));
   return ref;
 }
 
-void destroyObject(mxArray* obj) {
+void destroyObject(uint64_t ref) {
   if (!ObjectCollector::hasInstance()) {
 #ifdef MEX_DEBUG
     mexWarnMsgTxt("ObjectCollector already destroyed");
@@ -24,10 +19,7 @@ void destroyObject(mxArray* obj) {
     return;  // silent return. Destruction workflow is in progress (ObjectCollector already destroyed)
   }
 
-  auto ref = getObject(obj);
   if (!ObjectCollector::unregisterObject(ref)) {
     throw MxException(LOCATION(), "mLibKriging:nonExistingRef", "ObjectRef requested to unregister does not exist");
   }
-  mxArray* out = mxCreateNumericMatrix(0, 0, mxUINT64_CLASS, mxREAL);
-  mxSetProperty(obj, 0, "ref", out);
 }

--- a/bindings/Octave/tools/ObjectAccessor.hpp
+++ b/bindings/Octave/tools/ObjectAccessor.hpp
@@ -8,29 +8,15 @@
 #include "mex.h"
 
 struct ObjectRef {};
+struct EmptyObject {};
 
 template <typename T, typename... Args>
-ObjectCollector::ref_t buildObject(mxArray* obj, Args... args) {
-  mxArray* objectRef = mxGetProperty(obj, 0, "ref");
-  if (objectRef == nullptr) {
-    throw MxException(LOCATION(), "mLibKriging:badObject", "object does not contain 'ref' property");
-  }
-
-  if (!mxIsEmpty(objectRef)) {
-    throw MxException(
-        LOCATION(), "mLibKriging:objectAlreadyBuilt", "object already contain a non empty 'ref' property");
-  }
-
-  auto ref = ObjectCollector::registerObject(new T{args...});
-  mxArray* out = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
-  *((uint64_t*)mxGetData(out)) = ref;
-  mxSetProperty(obj, 0, "ref", out);
-
-  return ref;
+ObjectCollector::ref_t buildObject(Args... args) {
+  return ObjectCollector::registerObject(new T{args...});
 }
 
 ObjectCollector::ref_t getObject(const mxArray* obj);
 
-void destroyObject(mxArray* obj);
+void destroyObject(uint64_t ref);
 
 #endif  // LIBKRIGING_BINDINGS_OCTAVE_TOOLS_OBJECTACCESSOR_HPP

--- a/bindings/Octave/tools/ObjectCollector.hpp
+++ b/bindings/Octave/tools/ObjectCollector.hpp
@@ -2,8 +2,8 @@
 #define LIBKRIGING_BINDINGS_OCTAVE_TOOLS_OBJECTCOLLECTOR_HPP
 
 #include <cassert>
-#include <unordered_map>
 #include <memory>
+#include <unordered_map>
 
 #include "NonCopyable.hpp"
 

--- a/bindings/Octave/tools/mx_accessor.hpp
+++ b/bindings/Octave/tools/mx_accessor.hpp
@@ -21,7 +21,7 @@ template <typename T>
 auto converter(mxArray*);
 
 template <typename T>
-void setter(T&, mxArray*&);
+void setter(const T&, mxArray*&);
 
 /* Specialization */
 
@@ -75,15 +75,34 @@ inline auto converter<ObjectRef>(mxArray* x) {
 }
 
 template <>
-inline void setter<arma::vec>(arma::vec& v, mxArray*& x) {
+inline auto converter<uint64_t>(mxArray* x) {
+  if (!mxIsUint64(x) || mxIsComplex(x) || mxGetNumberOfElements(x) != 1) {
+    throw MxException(LOCATION(), "mLibKriging:badType", "not an unsigned 64bits int");
+  }
+  return *static_cast<uint64_t*>(mxGetData(x));
+}
+
+template <>
+inline void setter<arma::vec>(const arma::vec& v, mxArray*& x) {
   x = mxCreateNumericMatrix(v.n_rows, v.n_cols, mxDOUBLE_CLASS, mxREAL);
   if (false && v.mem_state == 0 && v.n_elem > arma::arma_config::mat_prealloc) {
     // FIXME hard trick; use internal implementation of arma::~Mat
     arma::access::rw(v.mem_state) = 2;
-    mxSetPr(x, v.memptr());
+    mxSetPr(x, const_cast<double*>(v.memptr()));
   } else {
     std::memcpy(mxGetPr(x), v.memptr(), sizeof(double) * v.n_rows * v.n_cols);
   }
+}
+
+template <>
+inline void setter<uint64_t>(const uint64_t& v, mxArray*& x) {
+  x = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
+  *static_cast<uint64_t*>(mxGetData(x)) = v;
+}
+
+template <>
+inline void setter<EmptyObject>(const EmptyObject& v, mxArray*& x) {
+  x = mxCreateNumericMatrix(0, 0, mxUINT64_CLASS, mxREAL);
 }
 
 #endif  // LIBKRIGING_BINDINGS_OCTAVE_TOOLS_MX_ACCESSOR_HPP


### PR DESCRIPTION
Migration to Octave 4 API (no more `mxSetProperty` and `mxGetProperty`).

In Octave 4, since error or exception in .m execution can lead to non standard exit (without error code), managers around test have been done (one for catching error in .m as error, non a successful exit, one for exit without error status code).