### PR TITLE
fix: prevent fork-after-threads deadlock when R forks child processes

### DIFF
--- a/src/lib/Kriging.cpp
+++ b/src/lib/Kriging.cpp
@@ -83,6 +83,41 @@ openblas_set_num_threads_t get_openblas_set_num_threads() {
 #endif
 #endif
 
+// Register pthread_atfork handlers so that forked child processes (e.g. R's
+// parallel::mclapply) inherit a clean, single-threaded BLAS/OMP state instead
+// of a locked idle thread pool that causes deadlocks.
+//
+// The prepare handler runs in the parent just before fork(): it sets BLAS and
+// OMP to 1 thread so no new parallel work can start during the fork window.
+// The child handler re-asserts single-threading in case the runtime inherited
+// stale state.  The parent handler is omitted (nullptr): the next fit() call
+// will reset threads_per_worker as needed.
+#if !defined(_WIN32) && defined(_POSIX_VERSION)
+#include <pthread.h>
+namespace {
+
+void libkriging_atfork_quiesce() {
+#if !defined(__APPLE__) || !defined(__arm64__)
+  auto fn = get_openblas_set_num_threads();
+  if (fn) fn(1);
+#endif
+#ifdef _OPENMP
+  omp_set_num_threads(1);
+#endif
+}
+
+struct ForkSafeRegistrar {
+  ForkSafeRegistrar() {
+    pthread_atfork(libkriging_atfork_quiesce,  // prepare: quiesce before fork
+                   nullptr,                    // parent:  restored by next fit()
+                   libkriging_atfork_quiesce); // child:   ensure clean state
+  }
+};
+static ForkSafeRegistrar fork_safe_registrar;
+
+}  // namespace
+#endif  // !_WIN32 && _POSIX_VERSION
+
 /************************************************/
 /**      Kriging implementation        **/
 /************************************************/
@@ -885,26 +920,40 @@ LIBKRIGING_EXPORT void Kriging::fit(const arma::vec& y,
       auto parsed_bfgs = Optim::parse_method(optim, "BFGS");
       int multistart = parsed_bfgs.second;
 
-      // Configure threads for Armadillo/BLAS to balance nested parallelism
-      // Each of the 'multistart' threads will use internal parallelism
+      // Configure threads for Armadillo/BLAS to balance nested parallelism.
+      // Each of the 'multistart' workers uses internal BLAS/OMP parallelism.
+      // A RAII guard resets to 1 thread when the scope exits — this collapses
+      // the idle thread pool so a subsequent fork() (e.g. R's mclapply) does
+      // not inherit locked mutexes and deadlock.
       unsigned int n_cpu = std::thread::hardware_concurrency();
+      struct ThreadCountGuard {
+        bool active = false;
+        ThreadCountGuard() = default;
+        void set(unsigned int n) {
+          active = true;
+#if !defined(__APPLE__) || !defined(__arm64__)
+          auto fn = get_openblas_set_num_threads();
+          if (fn) fn(static_cast<int>(n));
+#endif
+#ifdef _OPENMP
+          omp_set_num_threads(static_cast<int>(n));
+#endif
+        }
+        ~ThreadCountGuard() {
+          if (!active) return;
+#if !defined(__APPLE__) || !defined(__arm64__)
+          auto fn = get_openblas_set_num_threads();
+          if (fn) fn(1);
+#endif
+#ifdef _OPENMP
+          omp_set_num_threads(1);
+#endif
+        }
+      } thread_guard;
+
       if (n_cpu > 0 && multistart > 1) {
         unsigned int threads_per_worker = std::max(1u, n_cpu / multistart);
-
-        // Set OpenBLAS threads (if available)
-        // Note: Skip on macOS ARM64 where Accelerate framework is used
-#if !defined(__APPLE__) || !defined(__arm64__)
-        auto openblas_fn = get_openblas_set_num_threads();
-        if (openblas_fn != nullptr) {
-          openblas_fn(threads_per_worker);
-        }
-#endif
-
-// Set OpenMP threads (for Armadillo operations that use OpenMP)
-#ifdef _OPENMP
-        omp_set_num_threads(threads_per_worker);
-#endif
-
+        thread_guard.set(threads_per_worker);
         if (Optim::log_level > Optim::log_none) {
           arma::cout << "Threads per worker: " << threads_per_worker << " (total CPUs: " << n_cpu
                      << ", multistart: " << multistart << ")" << arma::endl;


### PR DESCRIPTION
## Problem

When libKriging is loaded inside R (via rlibkriging) and R forks child processes using `parallel::mclapply`, the children can deadlock permanently in `futex()`.

Root cause: `Kriging::fit()` with multistart BFGS calls `openblas_set_num_threads(N)` and `omp_set_num_threads(N)` before the optimization, but **never restores to 1 thread afterwards**. This leaves an idle OpenBLAS/libgomp thread pool alive between `fit()` calls. When the host process forks, children inherit locked futexes from threads that do not survive the fork → permanent deadlock.

Observed on Linux with `libopenblaso-r0.3.15.so` (OpenBLAS built with OpenMP). Reproduced reliably in the EGRI Bayesian optimization benchmark at iteration 18 of Gauss4 (first iteration where matrix size triggers BLAS thread initialization), where 28 forked R child processes all blocked on a single futex indefinitely.

## Fix (Kriging.cpp)

**1. RAII `ThreadCountGuard` around multistart BFGS** (primary fix)

Replaces the bare `openblas_fn(threads_per_worker)` / `omp_set_num_threads()` calls with a scoped guard whose destructor resets both to 1 thread on exit (including on exception). After each `fit()`, the idle thread pool collapses back to 1 thread so there is nothing to deadlock on a subsequent `fork()`.

**2. `pthread_atfork` handlers** (defense-in-depth, POSIX only)

Registered once at library load via a static initializer. The prepare handler calls `openblas_set_num_threads(1)` + `omp_set_num_threads(1)` just before `fork()` so no BLAS/OMP work can start during the fork window. The child handler re-asserts single-threading. The parent handler is `nullptr` — restored automatically by the next `fit()` call.

No-op on Windows (`_WIN32`).

## Testing

Verified by running the EGRI benchmark (Gauss4, 4D, n up to 34) with `parallel::mclapply` for parallel multi-start optimization. Previously deadlocked at iteration 18; passes all 30 seeds cleanly after this patch.