### PR TITLE
fix: align *Kriging() constructors across bindings (R noise/objective/regmodel + Julia parameters)

### DIFF
--- a/bindings/Julia/jlibkriging/src/jlibkriging.jl
+++ b/bindings/Julia/jlibkriging/src/jlibkriging.jl
@@ -90,6 +90,10 @@ Fit a Kriging model. `objective` selects the fit criterion: `"LL"`
 posterior), or `"VLL"`/`"VLL(m)"` for the Vecchia approximated log-likelihood
 with `m` conditioning neighbors (default 30) — O(n m^3) per evaluation instead
 of O(n^3), recommended for large designs in low dimension.
+
+Initial or fixed hyper-parameters can be passed either via the `sigma2`,
+`theta`, `beta`, `nugget` keywords, or as a `parameters` dict with the same
+keys (for API consistency with `WarpKriging`/`MLPKriging`).
 """
 function Kriging(y::Vector{Float64}, X::Matrix{Float64}, kernel::String;
                  noise::Union{Nothing,String,Float64,Vector{Float64}}=nothing,
@@ -97,6 +101,7 @@ function Kriging(y::Vector{Float64}, X::Matrix{Float64}, kernel::String;
                  normalize::Bool=false,
                  optim::String="BFGS",
                  objective::String="LL",
+                 parameters::Union{Nothing,AbstractDict}=nothing,
                  sigma2::Union{Nothing,Float64}=nothing,
                  is_sigma2_estim::Bool=true,
                  theta::Union{Nothing,Vector{Float64}}=nothing,
@@ -107,6 +112,20 @@ function Kriging(y::Vector{Float64}, X::Matrix{Float64}, kernel::String;
                  is_nugget_estim::Bool=true)
     n, d = size(X)
     @assert length(y) == n
+
+    # `parameters` is an alternative to the individual sigma2/theta/beta/nugget
+    # kwargs, for API consistency with WarpKriging/MLPKriging. Keys present in
+    # the dict override the matching kwargs.
+    if parameters !== nothing
+        haskey(parameters, "sigma2")          && (sigma2          = Float64(parameters["sigma2"]))
+        haskey(parameters, "theta")           && (theta           = Vector{Float64}(parameters["theta"]))
+        haskey(parameters, "beta")            && (beta            = Vector{Float64}(parameters["beta"]))
+        haskey(parameters, "nugget")          && (nugget          = Float64(parameters["nugget"]))
+        haskey(parameters, "is_sigma2_estim") && (is_sigma2_estim = Bool(parameters["is_sigma2_estim"]))
+        haskey(parameters, "is_theta_estim")  && (is_theta_estim  = Bool(parameters["is_theta_estim"]))
+        haskey(parameters, "is_beta_estim")   && (is_beta_estim   = Bool(parameters["is_beta_estim"]))
+        haskey(parameters, "is_nugget_estim") && (is_nugget_estim = Bool(parameters["is_nugget_estim"]))
+    end
 
     # Determine noise_model string and noise vector
     if noise === nothing
@@ -1216,6 +1235,7 @@ function NestedKriging(y::Vector{Float64}, X::Matrix{Float64}, kernel::String, n
                        regmodel::String="constant",
                        optim::String="BFGS",
                        objective::String="LL",
+                       parameters::Union{Nothing,AbstractDict}=nothing,
                        sigma2::Union{Nothing,Float64}=nothing,
                        is_sigma2_estim::Bool=true,
                        theta::Union{Nothing,Vector{Float64}}=nothing,
@@ -1224,6 +1244,17 @@ function NestedKriging(y::Vector{Float64}, X::Matrix{Float64}, kernel::String, n
                        is_beta_estim::Bool=true)
     n, d = size(X)
     @assert length(y) == n
+
+    # `parameters` mirrors WarpKriging/MLPKriging for API consistency; keys
+    # present in the dict override the matching kwargs.
+    if parameters !== nothing
+        haskey(parameters, "sigma2")          && (sigma2          = Float64(parameters["sigma2"]))
+        haskey(parameters, "theta")           && (theta           = Vector{Float64}(parameters["theta"]))
+        haskey(parameters, "beta")            && (beta            = Vector{Float64}(parameters["beta"]))
+        haskey(parameters, "is_sigma2_estim") && (is_sigma2_estim = Bool(parameters["is_sigma2_estim"]))
+        haskey(parameters, "is_theta_estim")  && (is_theta_estim  = Bool(parameters["is_theta_estim"]))
+        haskey(parameters, "is_beta_estim")   && (is_beta_estim   = Bool(parameters["is_beta_estim"]))
+    end
     sigma2_ptr = sigma2 === nothing ? C_NULL : Ref(sigma2)
     theta_ptr = theta === nothing ? C_NULL : theta
     theta_n = theta === nothing ? 0 : length(theta)

--- a/bindings/Julia/jlibkriging/tests/kriging_parametric_test.jl
+++ b/bindings/Julia/jlibkriging/tests/kriging_parametric_test.jl
@@ -80,3 +80,20 @@ end
         end
     end
 end
+
+# API consistency: `parameters` dict is an alternative to the sigma2/theta/... kwargs.
+@testset "Kriging parameters= dict" begin
+    rng = MersenneTwister(123)
+    n, d = 40, 2
+    X = rand(rng, n, d)
+    y = f_parametric(X)
+
+    k_dict = Kriging(y, X, "matern5_2"; optim="none",
+                     parameters=Dict("theta" => fill(0.3, d), "sigma2" => 1.0,
+                                     "is_theta_estim" => false, "is_sigma2_estim" => false))
+    k_kw = Kriging(y, X, "matern5_2"; optim="none",
+                   theta=fill(0.3, d), sigma2=1.0,
+                   is_theta_estim=false, is_sigma2_estim=false)
+    @test isapprox(theta(k_dict), theta(k_kw); atol=1e-8)
+    @test isapprox(sigma2(k_dict), sigma2(k_kw); atol=1e-8)
+end

--- a/bindings/Julia/jlibkriging/tests/nested_kriging_test.jl
+++ b/bindings/Julia/jlibkriging/tests/nested_kriging_test.jl
@@ -68,3 +68,15 @@ end
     @test maximum(abs.(p.mean .- y)) < 1e-3  # NK interpolates under warping
     @test all(p.stdev .>= 0)
 end
+
+@testset "NestedKriging parameters= dict" begin
+    import Random
+    rng = Random.MersenneTwister(123)
+    n, d = 100, 2
+    X = rand(rng, n, d)
+    y = [f_test(X[i, :]) for i in 1:n]
+    k = NestedKriging(y, X, "matern5_2", 4; parameters=Dict("theta" => fill(0.3, d)))
+    p = predict(k, X)
+    @test length(p.mean) == n
+    @test all(isfinite, p.mean)
+end

--- a/bindings/R/rlibkriging/R/KrigingClass.R
+++ b/bindings/R/rlibkriging/R/KrigingClass.R
@@ -98,16 +98,28 @@ classKriging <- function(nk) {
 #' s <- simulate(k, nsim = 10, seed = 123, x = x)
 #'
 #' matlines(x, s, col = rgb(0, 0, 1, 0.2), type = "l", lty = 1)
+# Validate the `objective` argument. Unlike match.arg(), this accepts the
+# Vecchia approximated log-likelihood "VLL" / "VLL(m)" in addition to the
+# classic "LL" / "LOO" / "LMP" (kept consistent with the Python/Julia bindings,
+# which pass `objective` as a free string).
+.match_kriging_objective <- function(objective) {
+    objective <- objective[[1L]]
+    if (!grepl("^(LL|LOO|LMP|VLL(\\([0-9]+\\))?)$", objective))
+        stop("'objective' must be one of \"LL\", \"LOO\", \"LMP\", \"VLL\" or \"VLL(m)\" (got \"",
+             objective, "\")", call. = FALSE)
+    objective
+}
+
 Kriging <- function(y=NULL, X=NULL, kernel=NULL,
-                    noise = NULL,
-                    regmodel = c("constant", "linear", "interactive", "none"),
+                    regmodel = c("constant", "linear", "interactive", "quadratic", "none"),
                     normalize = FALSE,
                     optim = c("BFGS", "none"),
                     objective = c("LL", "LOO", "LMP"),
-                    parameters = NULL) {
+                    parameters = NULL,
+                    noise = NULL) {
 
     regmodel <- match.arg(regmodel)
-    objective <- match.arg(objective)
+    objective <- .match_kriging_objective(objective)
     if (is.character(optim)) optim <- optim[1] #optim <- match.arg(optim) because we can use BFGS10 for 10 (multistart) BFGS
 
     # Determine noise_model from noise argument:
@@ -266,16 +278,16 @@ print.Kriging <- function(x, ...) {
 #' fit(k,y,X)
 #' print(k)
 fit.Kriging <- function(object, y, X,
-                    noise = NULL,
-                    regmodel = c("constant", "linear", "interactive", "none"),
+                    regmodel = c("constant", "linear", "interactive", "quadratic", "none"),
                     normalize = FALSE,
                     optim = c("BFGS", "none"),
                     objective = c("LL", "LOO", "LMP"),
-                    parameters = NULL, ...) {
+                    parameters = NULL,
+                    noise = NULL, ...) {
     if (length(L <- list(...)) > 0) warnOnDots(L)
 
     regmodel <- match.arg(regmodel)
-    objective <- match.arg(objective)
+    objective <- .match_kriging_objective(objective)
     if (is.character(optim)) optim <- optim[1] #optim <- match.arg(optim) because we can use BFGS10 for 10 (multistart) BFGS
 
     kriging_fit(object, y, X,

--- a/bindings/R/rlibkriging/tests/testthat/test-KrigingConstructorConsistency.R
+++ b/bindings/R/rlibkriging/tests/testthat/test-KrigingConstructorConsistency.R
@@ -1,0 +1,35 @@
+## Constructor argument consistency across bindings (see PR).
+library(testthat)
+library(rlibkriging)
+
+context("Kriging constructor argument consistency")
+
+set.seed(123)
+X <- as.matrix(runif(12))
+f <- function(x) 1 - 1 / 2 * (sin(12 * x) / (1 + x) + 2 * cos(7 * x) * x^5 + 0.7)
+y <- f(X)
+
+test_that("objective = 'VLL(m)' is accepted (Vecchia log-likelihood)", {
+  expect_error(Kriging(y, X, "matern5_2", objective = "VLL(3)"), NA)
+  expect_error(Kriging(y, X, "matern5_2", objective = "VLL"), NA)
+})
+
+test_that("objective still accepts LL / LOO / LMP and rejects unknown values", {
+  expect_error(Kriging(y, X, "gauss", objective = "LOO"), NA)
+  expect_error(Kriging(y, X, "gauss", objective = "LMP"), NA)
+  expect_error(Kriging(y, X, "gauss", objective = "NOPE"))
+})
+
+test_that("regmodel = 'quadratic' is available", {
+  expect_error(Kriging(y, X, "matern3_2", regmodel = "quadratic"), NA)
+})
+
+test_that("noise is the last argument (aligned with Python / WarpKriging)", {
+  # named form (recommended) keeps working
+  expect_error(Kriging(y, X, "gauss", noise = "nugget"), NA)
+  # positional form: noise is now after parameters
+  expect_error(
+    Kriging(y, X, "gauss", "constant", FALSE, "BFGS", "LL", NULL, "nugget"),
+    NA
+  )
+})


### PR DESCRIPTION
Aligns the `*Kriging()` constructors across bindings — the 4 inconsistencies found while auditing them.

## R binding (#1, #2, #3)
1. **`objective="VLL(m)"` was rejected.** `match.arg(objective)` restricted the value to `LL`/`LOO`/`LMP`, so the Vecchia objective — documented in roxygen and used by the shipped R notebook `kriging_vecchia_branin2d_r.ipynb` — raised an error. Replaced with `.match_kriging_objective()`, which also accepts `"VLL"` / `"VLL(m)"`, matching Python and Julia (free string).
2. **`noise` position.** It was the 4th argument (just after `kernel`) in `Kriging()`/`fit.Kriging()`, whereas Python and R's own `WarpKriging` put it last. Moved to the end. All internal calls already pass `noise=` by name and no repo code uses it positionally.
3. **`regmodel` was missing `"quadratic"`** (present in the C++ `Trend` enum and the roxygen doc, but omitted from the `match.arg` choices). Added.

Applied to both `Kriging()` and `fit.Kriging()`; covered by `tests/testthat/test-KrigingConstructorConsistency.R`.

## Julia binding (#4)
`Kriging`/`NestedKriging` only exposed the typed `sigma2`/`theta`/`beta`/`nugget` kwargs, while `WarpKriging`/`MLPKriging` take a `parameters` dict. Added an optional `parameters::Union{Nothing,AbstractDict}` to `Kriging` and `NestedKriging` (keys override the matching kwargs) so all four classes accept `parameters`. **Additive and backward compatible** — the existing kwargs path is untouched. New tests check the `parameters`-dict vs kwargs equivalence (`optim="none"`) for both classes.

## Validation
R and Julia aren't installable in my sandbox, so the R/Julia changes were reviewed by inspection and are validated by the repo's R and Julia CI on this PR — the added tests exercise the new code paths.
