### PR TITLE
ci(release): fix Windows release jobs (cmake >= 4.2 for VS2026)

### DIFF
--- a/.github/workflows/release-cpp.yml
+++ b/.github/workflows/release-cpp.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   DEBUG_CI: true
+  # cmake >= 4 rejects deps declaring cmake_minimum_required < 3.5 (pinned pybind11)
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   check-release-consistency:
@@ -131,7 +133,7 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@v4.3.2
         with:
-          cmakeVersion: '~3.24.0'
+          cmakeVersion: '~4.2.0'
 
       - name: before_script
         shell: bash

--- a/.github/workflows/release-matlab.yml
+++ b/.github/workflows/release-matlab.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@v4.3.2
         with:
-          cmakeVersion: '~3.24.0'
+          cmakeVersion: '~4.2.0'
 
       - name: before_script
         shell: bash

--- a/.github/workflows/release-octave.yml
+++ b/.github/workflows/release-octave.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   DEBUG_CI: true
+  # cmake >= 4 rejects deps declaring cmake_minimum_required < 3.5 (pinned pybind11)
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   check-release-consistency:
@@ -134,7 +136,7 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@v4.3.2
         with:
-          cmakeVersion: '~3.24.0'
+          cmakeVersion: '~4.2.0'
 
       - name: before_script
         shell: bash

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   DEBUG_CI: true
+  # cmake >= 4 rejects deps declaring cmake_minimum_required < 3.5 (pinned pybind11)
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
   check-release-consistency:
@@ -157,7 +159,7 @@ jobs:
       - name: Setup cmake
         uses: lukka/get-cmake@v4.3.2
         with:
-          cmakeVersion: '~3.24.0'
+          cmakeVersion: '~4.2.0'
 
       - name: before_script
         shell: bash


### PR DESCRIPTION
The v1.1.0 release Windows jobs (C++, Python, Octave) failed identically to `main.yml` before #320: the `release-*` workflows still pinned `cmake ~3.24.0`, which doesn't know the "Visual Studio 18 2026" generator on the `windows-2025-vs2026` image → falls back to NMake → `CMAKE_C_COMPILER not set`. (R passed: it builds via the R/Rtools toolchain, not the VS generator.)

Bumps the cmake pin to `~4.2.0` in `release-cpp` / `release-python` / `release-octave` / `release-matlab`, and adds `CMAKE_POLICY_VERSION_MINIMUM="3.5"` for the pinned pybind11 submodule — same fix as #320, which only touched `main.yml`.

`release-r.yml` left as-is (its Windows job already passes).

Note: the `v1.1.0` GitHub release is already published but incomplete (only Linux/macOS C++ and R assets). After this merges, the release needs to be re-run to add the Windows/Python/Octave artifacts.
