### PR TITLE
ci(windows): retry choco install to absorb transient community-feed 504s

### DIFF
--- a/tools/common/choco.sh
+++ b/tools/common/choco.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared helper: retry `choco install` to absorb transient failures from the
+# Chocolatey community feed (notably HTTP 504 Gateway Timeout when fetching a
+# package version, which otherwise fails the Windows CI/release jobs).
+#
+# Usage:   choco_install <package> [extra choco args...]
+# Tunable: CHOCO_MAX_RETRIES (default 5), CHOCO_RETRY_DELAY seconds (default 15).
+#
+# Written to be safe under `set -e`: the inner choco call is guarded with `||`.
+choco_install() {
+  local attempt=1 max="${CHOCO_MAX_RETRIES:-5}" delay="${CHOCO_RETRY_DELAY:-15}" rc
+  while true; do
+    rc=0
+    choco install --no-progress -y "$@" || rc=$?
+    # 0 = success; 3010 / 1641 = success but a reboot was requested
+    if [ "$rc" -eq 0 ] || [ "$rc" -eq 3010 ] || [ "$rc" -eq 1641 ]; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max" ]; then
+      echo "choco_install: '$*' failed after ${max} attempt(s) (last rc=${rc})" >&2
+      return "$rc"
+    fi
+    echo "choco_install: '$*' failed (attempt ${attempt}/${max}, rc=${rc}); retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}

--- a/tools/octave-windows/install.sh
+++ b/tools/octave-windows/install.sh
@@ -8,6 +8,7 @@ fi
 BASEDIR=$(dirname "$0")
 BASEDIR=$(cd "$BASEDIR" && pwd -P)
 test -f "${BASEDIR}"/loadenv.sh && . "${BASEDIR}"/loadenv.sh 
+. "${BASEDIR}"/../common/choco.sh
 
 if [[ "${ENABLE_COVERAGE}" == "on" ]]; then
     echo "Coverage not supported for Windows"
@@ -29,13 +30,13 @@ $HOME/Miniconda3/Scripts/conda.exe install -y --quiet -n base -c conda-forge ope
 
 # https://chocolatey.org/docs/commands-install
 # https://chocolatey.org/packages/make
-choco install -y --no-progress make --version 4.3
+choco_install make --version 4.3
 
 if [[ "$ENABLE_OCTAVE_BINDING" == "on" ]]; then
   # select your version from https://community.chocolatey.org/packages/octave.portable#versionhistory
   # Don't forget to update loadenv.sh with the related path
   # Using 9.2.0 as 6.2.0 is no longer available on GNU FTP servers
-  choco install -y --no-progress octave.portable --version=9.2.0
+  choco_install octave.portable --version=9.2.0
   
   # Note: We use Octave's built-in MinGW compiler instead of installing a separate mingw package
   # This avoids conflicts between different MinGW versions

--- a/tools/r-windows/install.sh
+++ b/tools/r-windows/install.sh
@@ -7,6 +7,7 @@ fi
 
 BASEDIR=$(dirname "$0")
 BASEDIR=$(cd "$BASEDIR" && pwd -P)
+. "${BASEDIR}"/../common/choco.sh
 
 "${BASEDIR}"/../windows/install.sh
 
@@ -59,7 +60,7 @@ if [ "${GITHUB_ACTIONS:=false}" == "false" ]; then
 fi
 
 # For R packaging
-choco install -y --no-progress zip
+choco_install zip
 
 test -f "${BASEDIR}"/loadenv.sh && . "${BASEDIR}"/loadenv.sh 
 

--- a/tools/windows/install.sh
+++ b/tools/windows/install.sh
@@ -8,6 +8,7 @@ fi
 BASEDIR=$(dirname "$0")
 BASEDIR=$(cd "$BASEDIR" && pwd -P)
 test -f "${BASEDIR}"/loadenv.sh && . "${BASEDIR}"/loadenv.sh 
+. "${BASEDIR}"/../common/choco.sh
 
 if [[ "${ENABLE_COVERAGE}" == "on" ]]; then
     echo "Coverage not supported for Windows"
@@ -42,8 +43,8 @@ $HOME/Miniconda3/Scripts/conda.exe install -y --quiet -n base -c conda-forge ope
 
 # https://chocolatey.org/docs/commands-install
 # required to compile fortran part
-choco install mingw
-choco install -y --no-progress make --version 4.3
+choco_install mingw
+choco_install make --version 4.3
 
 if [[ "$ENABLE_PYTHON_BINDING" == "on" ]]; then
   # Check if python is available (it could be a python wrapper given by Windows)


### PR DESCRIPTION
Windows install steps occasionally fail on a **transient** Chocolatey community-feed error, e.g.:

> Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(Id='make',Version='4.3.0')' … 504 (Gateway Timeout)

This aborts the C++ / Octave / R Windows jobs for no real reason.

## Change
- New shared helper `tools/common/choco.sh` with `choco_install()`:
  - retries with exponential backoff (5 attempts, 15s base delay; tunable via `CHOCO_MAX_RETRIES` / `CHOCO_RETRY_DELAY`),
  - treats reboot-required exit codes (`3010`/`1641`) as success,
  - `set -e` safe (the inner `choco` call is guarded with `||`).
- `tools/{windows,octave-windows,r-windows}/install.sh` now route their choco installs (`mingw`, `make`, `octave.portable`, `zip`) through `choco_install`.

Verified locally: 2 simulated 504s → retried → success and the script continues; a permanent failure still aborts after the retry budget.
