### PR TITLE
test(python): stop hard-coding version in loading_test (fixes Python/loading)

### DIFF
--- a/bindings/Python/pylibkriging/tests/loading_test.py
+++ b/bindings/Python/pylibkriging/tests/loading_test.py
@@ -1,12 +1,28 @@
 import os
+import re
 
 import numpy as np
 import pylibkriging as m
 import pytest
 
 
+def _expected_version():
+    """Read the version from the single source of truth (cmake/version.cmake)
+    so this test does not need updating on every release."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    vfile = os.path.normpath(
+        os.path.join(here, "..", "..", "..", "..", "cmake", "version.cmake"))
+    with open(vfile) as f:
+        data = f.read()
+
+    def part(key):
+        return re.search(r"^set\(KRIGING_VERSION_%s (\d+)\)$" % key, data, re.M).group(1)
+
+    return "%s.%s.%s" % (part("MAJOR"), part("MINOR"), part("PATCH"))
+
+
 def test_version():
-    assert m.__version__ == '1.0.0'
+    assert m.__version__ == _expected_version()
 
 
 def test_generic_load_dispatches_classes():


### PR DESCRIPTION
`bindings/Python/pylibkriging/tests/loading_test.py` hard-coded `assert m.__version__ == '1.0.0'`. After the 1.1.0 bump the built package reports `1.1.0`, so the `Python/loading` test (ctest #2) failed on **every** platform, turning `Build and tests` and `Code Analysis` red on master.

Fix: read the expected version from the single source of truth `cmake/version.cmake` (same regex `setup.py` already uses), so the assertion tracks the real version and won't go stale on future releases.

Test-only change — no effect on shipped artifacts (the Python release wheels already build & pass). Verified locally: the helper resolves `cmake/version.cmake` → `1.1.0`.

Note (separate, not addressed here): the Octave **release** Windows job shows two `NestedKriging` tests timing out (#84, #91) on the slow Octave/Windows runner — a perf/flakiness issue unrelated to this version fix.
