### PR TITLE
fix(R): don't let .match_kriging_objective hijack Kriging's roxygen/@export

### DIFF
--- a/bindings/R/rlibkriging/R/KrigingClass.R
+++ b/bindings/R/rlibkriging/R/KrigingClass.R
@@ -3,6 +3,18 @@
 ## As an S3 class, it has no formal definition.
 ## ****************************************************************************
 
+# Validate the `objective` argument. Unlike match.arg(), this accepts the
+# Vecchia approximated log-likelihood "VLL" / "VLL(m)" in addition to the
+# classic "LL" / "LOO" / "LMP" (kept consistent with the Python/Julia bindings,
+# which pass `objective` as a free string).
+.match_kriging_objective <- function(objective) {
+    objective <- objective[[1L]]
+    if (!grepl("^(LL|LOO|LMP|VLL(\\([0-9]+\\))?)$", objective))
+        stop("'objective' must be one of \"LL\", \"LOO\", \"LMP\", \"VLL\" or \"VLL(m)\" (got \"",
+             objective, "\")", call. = FALSE)
+    objective
+}
+
 #' Shortcut to provide functions to the S3 class "Kriging"
 #' @param nk A pointer to a C++ object of class "Kriging"
 #' @return An object of class "Kriging" with methods to access and manipulate the data
@@ -98,18 +110,6 @@ classKriging <- function(nk) {
 #' s <- simulate(k, nsim = 10, seed = 123, x = x)
 #'
 #' matlines(x, s, col = rgb(0, 0, 1, 0.2), type = "l", lty = 1)
-# Validate the `objective` argument. Unlike match.arg(), this accepts the
-# Vecchia approximated log-likelihood "VLL" / "VLL(m)" in addition to the
-# classic "LL" / "LOO" / "LMP" (kept consistent with the Python/Julia bindings,
-# which pass `objective` as a free string).
-.match_kriging_objective <- function(objective) {
-    objective <- objective[[1L]]
-    if (!grepl("^(LL|LOO|LMP|VLL(\\([0-9]+\\))?)$", objective))
-        stop("'objective' must be one of \"LL\", \"LOO\", \"LMP\", \"VLL\" or \"VLL(m)\" (got \"",
-             objective, "\")", call. = FALSE)
-    objective
-}
-
 Kriging <- function(y=NULL, X=NULL, kernel=NULL,
                     regmodel = c("constant", "linear", "interactive", "quadratic", "none"),
                     normalize = FALSE,


### PR DESCRIPTION
## Why rlibkriging CI is failing
In #323 the internal helper `.match_kriging_objective()` was inserted **between** the `Kriging` constructor's roxygen block and the `Kriging` function definition. roxygen attaches a `#'` block to the *next* definition, so the whole block — including `@export`, `@param` and `@examples` — got attached to `.match_kriging_objective` instead of `Kriging`.

On doc regeneration (which rlibkriging's `R CMD check` does) this:
- drops `export(Kriging)` from `NAMESPACE` → `Error: 'Kriging' is not an exported object from 'namespace:rlibkriging'` (failing examples **and** tests),
- writes a bogus `dot-match_kriging_objective.Rd` with the constructor's args → `checking Rd \usage sections` WARNING,
- breaks `NestedKriging.Rd`'s `\link{Kriging}` → `Rd cross-references` WARNING,
- `checking dependencies ... WARNING: Missing or unexported object 'rlibkriging::Kriging'`.

Net: `2 ERRORs, 3 WARNINGs`. `libKriging`'s own R job only builds+tests (no full check / doc regen) so it stayed green; `rlibkriging` runs the full CRAN check and caught it.

## Fix
Move `.match_kriging_objective()` to the top of `KrigingClass.R` (plain `#` comments, nothing roxygen-ish above it), so the roxygen block again documents `Kriging`. Pure relocation — no behaviour change. The fix syncs to `libKriging/rlibkriging` via `sync-as-submodule`.
