### PR TITLE
ci(sync): keep rlibkriging tools/gitmodules-shas in sync with submodule bumps

### DIFF
--- a/.github/workflows/sync-as-submodule.yml
+++ b/.github/workflows/sync-as-submodule.yml
@@ -22,6 +22,16 @@ jobs:
           git submodule update --init --recursive
           git submodule update --recursive --remote
 
+      - name: Refresh pinned submodule SHAs (for no-git installs / CRAN tarball)
+        run: |
+          # rlibkriging records submodule SHAs in tools/gitmodules-shas for
+          # install_github / CRAN tarball installs (no .git). Keep it in sync
+          # with the just-updated gitlinks, otherwise its check-gitmodules-shas
+          # CI job fails and install_github pulls a stale libKriging.
+          if [ -x tools/update_submodule_shas.sh ]; then
+            bash tools/update_submodule_shas.sh
+          fi
+
       - name: Commit
         run: |
           git config user.email "actions@github.com"


### PR DESCRIPTION
## The submodule-SHA problem in rlibkriging
`rlibkriging` embeds libKriging as the `src/libK` submodule and, for **no-git installs** (`install_github` / CRAN tarball, where there is no `.git`), pins the submodule commit in `tools/gitmodules-shas` (read by `tools/setup.sh`). It also has a CI job `check-gitmodules-shas` that fails if that file doesn't match the actual submodule gitlink.

This sync workflow bumps the **gitlink** (`git submodule update --remote`) but never updated `tools/gitmodules-shas`, so they drifted: the gitlink was at the latest libKriging master (`cd3638f0`) while `gitmodules-shas` was stuck at an old pre-1.1.0 commit (`102ff52`). Result in rlibkriging CI:
- `check-gitmodules-shas` / `devtools-install_github` **fail** on the mismatch,
- no-git installs pulled a **stale** libKriging (old R binding).

## Fix
After updating submodules, run rlibkriging's own `tools/update_submodule_shas.sh` so the pinned-SHA file tracks the gitlink; `git add --all` then commits both together. This keeps them in sync on every future bump.

Merging this triggers a sync run (with the fixed workflow) that will regenerate `tools/gitmodules-shas` in rlibkriging and unblock its CI.

Note: the earlier roxygen fix (#329) already cleared the R CMD check **ERRORs** in rlibkriging (Kriging is exported again); what remained was this submodule-SHA mismatch (+ a separate install **WARNING** unrelated to the SHA).
