### PR TITLE
ci(sync): refresh gitmodules-shas after staging gitlinks (fix #330 ordering)

### DIFF
--- a/.github/workflows/sync-as-submodule.yml
+++ b/.github/workflows/sync-as-submodule.yml
@@ -22,20 +22,20 @@ jobs:
           git submodule update --init --recursive
           git submodule update --recursive --remote
 
-      - name: Refresh pinned submodule SHAs (for no-git installs / CRAN tarball)
-        run: |
-          # rlibkriging records submodule SHAs in tools/gitmodules-shas for
-          # install_github / CRAN tarball installs (no .git). Keep it in sync
-          # with the just-updated gitlinks, otherwise its check-gitmodules-shas
-          # CI job fails and install_github pulls a stale libKriging.
-          if [ -x tools/update_submodule_shas.sh ]; then
-            bash tools/update_submodule_shas.sh
-          fi
-
       - name: Commit
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions - update submodules"
+          # Stage the bumped gitlinks FIRST: `git submodule update --remote`
+          # moves the submodules in the working tree but does not stage them,
+          # and tools/update_submodule_shas.sh reads `git ls-files --stage`
+          # (the index). So add first, then refresh the pinned-SHA file, then
+          # restage it, so tools/gitmodules-shas matches the new gitlinks
+          # (rlibkriging's check-gitmodules-shas job requires this).
           git add --all
+          if [ -x tools/update_submodule_shas.sh ]; then
+            bash tools/update_submodule_shas.sh
+            git add tools/gitmodules-shas
+          fi
           git commit -m "Update submodules" || echo "No changes to commit"
           git push


### PR DESCRIPTION
Follow-up to #330 — my previous fix ran the SHA refresh in the wrong order.

`tools/update_submodule_shas.sh` reads `git ls-files --stage` (the **index**), but `git submodule update --remote` only moves the submodule **working tree**; the bumped gitlink isn't in the index until `git add`. So running the refresh *before* `git add` recorded the **previous** SHA, leaving rlibkriging one commit behind:

```
ERROR: tools/gitmodules-shas is out of date!
 Expected: src/libK 7ff5ad41…   (gitlink)
 Actual:   src/libK cd3638f0…   (gitmodules-shas)
```

Fix: `git add --all` **first** (stages the new gitlinks), then run `update_submodule_shas.sh`, then restage `tools/gitmodules-shas`. Verified locally that `git ls-files --stage` only reflects a submodule bump after `git add`.

Merging this triggers a sync run (fixed order) that aligns rlibkriging's `tools/gitmodules-shas` with the gitlink and unblocks `check-gitmodules-shas` / `install_github`.
