### PR TITLE
bench: cross-package comparison benchmark on shared randomized LHS designs

### DIFF
--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -91,7 +91,7 @@ jobs:
 
   report:
     name: Aggregate report
-    needs: [bench-python, bench-r]
+    needs: [datasets, bench-python, bench-r]
     if: always() && needs.datasets.result == 'success'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -2,7 +2,13 @@ name: Comparison benchmark
 
 # Cross-package kriging benchmark on shared LHS designs.
 # Heavy job: manual trigger + monthly schedule, never on push/PR.
+# TEMPORARY: also run on this PR's branch so the new benchmark gets exercised
+# by CI before merge. Remove the push/pull_request triggers below once verified.
 on:
+  push:
+    branches: [feature/comparison-benchmark]
+  pull_request:
+    branches: [feature/comparison-benchmark]
   workflow_dispatch:
     inputs:
       repeats:

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -1,0 +1,116 @@
+name: Comparison benchmark
+
+# Cross-package kriging benchmark on shared LHS designs.
+# Heavy job: manual trigger + monthly schedule, never on push/PR.
+on:
+  workflow_dispatch:
+    inputs:
+      repeats:
+        description: 'Randomized design repetitions per case'
+        default: '10'
+      quick:
+        description: 'Quick mode (small subset of cases)'
+        type: boolean
+        default: false
+      budget:
+        description: 'Per-fit wall-clock budget (seconds)'
+        default: '300'
+  schedule:
+    - cron: '0 3 1 * *'  # monthly, 1st at 03:00 UTC
+
+env:
+  REPEATS: ${{ github.event.inputs.repeats || '10' }}
+  BUDGET: ${{ github.event.inputs.budget || '300' }}
+  QUICK: ${{ (github.event.inputs.quick == 'true') && '--quick' || '' }}
+
+jobs:
+  datasets:
+    name: Generate shared designs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install "numpy<2" scipy
+      - name: Generate LHS designs
+        working-directory: bench/comparison
+        run: python make_datasets.py --repeats "$REPEATS" $QUICK
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-datasets
+          path: bench/comparison/data
+
+  bench-python:
+    name: Python packages
+    needs: datasets
+    runs-on: ubuntu-22.04
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'  # GPy compatibility
+      - run: pip install "numpy<2" scipy pandas pylibkriging scikit-learn GPy smt openturns
+      - uses: actions/download-artifact@v4
+        with:
+          name: bench-datasets
+          path: bench/comparison/data
+      - name: Run Python benchmark
+        working-directory: bench/comparison
+        run: python run_python.py --budget "$BUDGET" --out results/python.csv
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-python
+          path: bench/comparison/results
+
+  bench-r:
+    name: R packages
+    needs: datasets
+    runs-on: ubuntu-22.04
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - name: Install R packages
+        run: |
+          Rscript -e 'install.packages(c("rlibkriging", "DiceKriging", "RobustGaSP"))'
+      - uses: actions/download-artifact@v4
+        with:
+          name: bench-datasets
+          path: bench/comparison/data
+      - name: Run R benchmark
+        working-directory: bench/comparison
+        run: Rscript run_r.R data results/r.csv "$BUDGET"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-r
+          path: bench/comparison/results
+
+  report:
+    name: Aggregate report
+    needs: [bench-python, bench-r]
+    if: always() && needs.datasets.result == 'success'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install "numpy<2" pandas
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bench-results-*
+          path: bench/comparison/results
+          merge-multiple: true
+      - name: Aggregate and publish summary
+        working-directory: bench/comparison
+        run: |
+          python aggregate.py --results results --out results/summary.md
+          cat results/summary.md >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-comparison-report
+          path: bench/comparison/results

--- a/bench/comparison/.gitignore
+++ b/bench/comparison/.gitignore
@@ -1,0 +1,2 @@
+data/
+results/

--- a/bench/comparison/README.md
+++ b/bench/comparison/README.md
@@ -1,0 +1,52 @@
+# Cross-package comparison benchmark
+
+Benchmarks libKriging (`pylibkriging`, `rlibkriging`) against classic kriging
+packages on standard response surfaces, with **identical, randomized designs**
+shared across all packages and both languages.
+
+| | Packages |
+|---|---|
+| Python | pylibkriging, scikit-learn, GPy, SMT, OpenTURNS |
+| R | rlibkriging, DiceKriging, RobustGaSP |
+
+## Protocol
+
+- Test functions ([Surjanovic & Bingham](https://www.sfu.ca/~ssurjano/)):
+  Branin (d=2), Hartmann-3, Hartmann-6, Borehole (d=8);
+  training sizes from 50 up to 1000 points.
+- Designs: Latin Hypercube (scipy `qmc`, seeded per `(n, rep)`), **10
+  repetitions** by default; a common 2000-point LHS test set per function.
+  Designs are generated once (`make_datasets.py`) and written to CSV, then
+  consumed as-is by the Python and R runners — every package sees exactly the
+  same conditioning points and test points.
+- Model: Matern 5/2 anisotropic kernel, constant trend, interpolation
+  (no nugget), hyperparameters by MLE with each package's default optimizer.
+- Metrics: fit time, prediction time, RMSE, Q², NLPD on the test set;
+  per-fit wall-clock budget (default 300 s), timeouts/errors recorded.
+- Report: median [q25; q75] over repetitions, per (function, n), written to
+  the GitHub Actions step summary and uploaded as an artifact.
+
+## Running locally
+
+```sh
+cd bench/comparison
+pip install "numpy<2" scipy pandas pylibkriging scikit-learn GPy smt openturns
+python make_datasets.py --repeats 10          # or --quick
+python run_python.py                          # results/python.csv
+Rscript run_r.R data results/r.csv 300        # needs rlibkriging, DiceKriging, RobustGaSP
+python aggregate.py                           # results/all.csv + summary.md
+```
+
+## CI
+
+`.github/workflows/bench-comparison.yml` — manual `workflow_dispatch`
+(inputs: `repeats`, `quick`, `budget`) plus a monthly schedule. It never runs
+on push/PR (too heavy). Python is pinned to 3.11 and `numpy<2` for GPy
+compatibility.
+
+## Fairness caveats
+
+Packages differ in optimizer, restarts, bounds and internal rescaling; this
+compares *default MLE fits* under a common kernel/trend, not tuned setups.
+Contributions refining per-package settings are welcome — please keep any
+change symmetric across packages.

--- a/bench/comparison/aggregate.py
+++ b/bench/comparison/aggregate.py
@@ -1,0 +1,65 @@
+"""Merge python.csv and r.csv into results/all.csv and a markdown summary
+(median over repetitions, with [q25; q75]) suitable for $GITHUB_STEP_SUMMARY.
+"""
+import argparse
+import glob
+import os
+
+import numpy as np
+import pandas as pd
+
+
+def fmt(series, digits=3):
+    s = series.dropna()
+    if s.empty:
+        return "—"
+    med, q1, q3 = s.median(), s.quantile(0.25), s.quantile(0.75)
+    return f"{med:.{digits}g} [{q1:.{digits}g}; {q3:.{digits}g}]"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results", default="results")
+    ap.add_argument("--out", default="results/summary.md")
+    args = ap.parse_args()
+
+    frames = [pd.read_csv(f) for f in glob.glob(
+        os.path.join(args.results, "*.csv"))
+        if os.path.basename(f) not in ("all.csv",)]
+    df = pd.concat(frames, ignore_index=True)
+    df.to_csv(os.path.join(args.results, "all.csv"), index=False)
+
+    lines = ["# libKriging comparison benchmark",
+             "",
+             f"Repetitions per case: {df.groupby(['func','n','package'])['rep'].count().max()}"
+             " — identical LHS designs shared by all packages.",
+             "Median [q25; q75] over repetitions. `—` = no successful run.",
+             ""]
+    for (func, n), sub in df.groupby(["func", "n"]):
+        d = int(sub["d"].iloc[0])
+        lines += [f"## {func} (d={d}, n={n})", "",
+                  "| package | fit time (s) | pred time (s) | RMSE | Q² | NLPD | ok/total |",
+                  "|---|---|---|---|---|---|---|"]
+        for pkg, g in sub.groupby("package"):
+            ok = (g["status"] == "ok").sum()
+            lines.append(
+                f"| {pkg} | {fmt(g['fit_time'])} | {fmt(g['pred_time'])} "
+                f"| {fmt(g['rmse'])} | {fmt(g['q2'], 4)} | {fmt(g['nlpd'])} "
+                f"| {ok}/{len(g)} |")
+        lines.append("")
+
+    lines += ["### Caveats",
+              "",
+              "Packages differ in optimizer, restarts, parameter bounds and",
+              "internal scaling; this compares *default MLE fits* with a",
+              "Matern 5/2 ARD kernel and constant trend, not tuned setups.",
+              ""]
+    out = "\n".join(lines)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w") as fh:
+        fh.write(out)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/comparison/functions.py
+++ b/bench/comparison/functions.py
@@ -1,0 +1,56 @@
+"""Classic response surfaces for surrogate benchmarking.
+
+All functions accept X of shape (n, d) in their *native* domain and return
+y of shape (n,). Domains are given by `DOMAINS[name]` as (d, 2) arrays.
+References: Surjanovic & Bingham, https://www.sfu.ca/~ssurjano/
+"""
+import numpy as np
+
+def branin(X):
+    x1, x2 = X[:, 0], X[:, 1]
+    a, b, c = 1.0, 5.1 / (4 * np.pi**2), 5 / np.pi
+    r, s, t = 6.0, 10.0, 1 / (8 * np.pi)
+    return a * (x2 - b * x1**2 + c * x1 - r) ** 2 + s * (1 - t) * np.cos(x1) + s
+
+_H3_ALPHA = np.array([1.0, 1.2, 3.0, 3.2])
+_H3_A = np.array([[3, 10, 30], [0.1, 10, 35], [3, 10, 30], [0.1, 10, 35]], float)
+_H3_P = 1e-4 * np.array([[3689, 1170, 2673], [4699, 4387, 7470],
+                         [1091, 8732, 5547], [381, 5743, 8828]], float)
+
+def hartmann3(X):
+    diff2 = (X[:, None, :] - _H3_P[None, :, :]) ** 2          # (n, 4, 3)
+    expo = np.exp(-np.sum(_H3_A[None, :, :] * diff2, axis=2))  # (n, 4)
+    return -expo @ _H3_ALPHA
+
+_H6_ALPHA = np.array([1.0, 1.2, 3.0, 3.2])
+_H6_A = np.array([[10, 3, 17, 3.5, 1.7, 8],
+                  [0.05, 10, 17, 0.1, 8, 14],
+                  [3, 3.5, 1.7, 10, 17, 8],
+                  [17, 8, 0.05, 10, 0.1, 14]], float)
+_H6_P = 1e-4 * np.array([[1312, 1696, 5569, 124, 8283, 5886],
+                         [2329, 4135, 8307, 3736, 1004, 9991],
+                         [2348, 1451, 3522, 2883, 3047, 6650],
+                         [4047, 8828, 8732, 5743, 1091, 381]], float)
+
+def hartmann6(X):
+    diff2 = (X[:, None, :] - _H6_P[None, :, :]) ** 2           # (n, 4, 6)
+    expo = np.exp(-np.sum(_H6_A[None, :, :] * diff2, axis=2))  # (n, 4)
+    return -expo @ _H6_ALPHA
+
+def borehole(X):
+    rw, r, Tu, Hu, Tl, Hl, L, Kw = (X[:, i] for i in range(8))
+    lnr = np.log(r / rw)
+    return (2 * np.pi * Tu * (Hu - Hl)) / (
+        lnr * (1 + 2 * L * Tu / (lnr * rw**2 * Kw) + Tu / Tl))
+
+FUNCTIONS = {"branin": branin, "hartmann3": hartmann3,
+             "hartmann6": hartmann6, "borehole": borehole}
+
+DOMAINS = {
+    "branin": np.array([[-5.0, 10.0], [0.0, 15.0]]),
+    "hartmann3": np.array([[0.0, 1.0]] * 3),
+    "hartmann6": np.array([[0.0, 1.0]] * 6),
+    "borehole": np.array([[0.05, 0.15], [100.0, 50000.0], [63070.0, 115600.0],
+                          [990.0, 1110.0], [63.1, 116.0], [700.0, 820.0],
+                          [1120.0, 1680.0], [9855.0, 12045.0]]),
+}

--- a/bench/comparison/make_datasets.py
+++ b/bench/comparison/make_datasets.py
@@ -1,0 +1,66 @@
+"""Generate shared, seeded LHS designs so that every package (Python and R)
+is fitted on *identical* conditioning points.
+
+Layout:
+  data/<func>/X_test.csv, y_test.csv                  (common test set)
+  data/<func>/n<N>/rep<K>/X_train.csv, y_train.csv    (K = 0..repeats-1)
+
+All CSVs have no header; full float precision (repr) so R reads bitwise-
+comparable values.
+"""
+import argparse
+import os
+
+import numpy as np
+from scipy.stats import qmc
+
+from functions import DOMAINS, FUNCTIONS
+
+CASES = {  # function -> training sizes
+    "branin": [50, 200, 1000],
+    "hartmann3": [100, 300, 1000],
+    "hartmann6": [200, 500, 1000],
+    "borehole": [200, 500, 1000],
+}
+QUICK_CASES = {"branin": [50], "hartmann6": [200]}
+N_TEST = 2000
+TEST_SEED = 20260717
+
+
+def lhs(n, dom, seed):
+    d = dom.shape[0]
+    u = qmc.LatinHypercube(d=d, seed=seed).random(n)
+    return qmc.scale(u, dom[:, 0], dom[:, 1])
+
+
+def save(path, arr):
+    np.savetxt(path, np.atleast_2d(arr.T).T, delimiter=",", fmt="%.17g")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repeats", type=int, default=10)
+    ap.add_argument("--quick", action="store_true")
+    ap.add_argument("--out", default="data")
+    args = ap.parse_args()
+
+    cases = QUICK_CASES if args.quick else CASES
+    for func, sizes in cases.items():
+        f, dom = FUNCTIONS[func], DOMAINS[func]
+        fdir = os.path.join(args.out, func)
+        os.makedirs(fdir, exist_ok=True)
+        Xt = lhs(N_TEST, dom, TEST_SEED)
+        save(os.path.join(fdir, "X_test.csv"), Xt)
+        save(os.path.join(fdir, "y_test.csv"), f(Xt))
+        for n in sizes:
+            for rep in range(args.repeats):
+                rdir = os.path.join(fdir, f"n{n}", f"rep{rep}")
+                os.makedirs(rdir, exist_ok=True)
+                X = lhs(n, dom, seed=1000 * n + rep)  # deterministic per (n, rep)
+                save(os.path.join(rdir, "X_train.csv"), X)
+                save(os.path.join(rdir, "y_train.csv"), f(X))
+        print(f"[make_datasets] {func}: sizes={sizes} repeats={args.repeats}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/comparison/run_python.py
+++ b/bench/comparison/run_python.py
@@ -1,0 +1,193 @@
+"""Benchmark pylibkriging against GPy, scikit-learn, SMT and OpenTURNS on the
+shared datasets produced by make_datasets.py.
+
+Common modelling choices (as close as each API allows):
+  * Matern 5/2 anisotropic (ARD) kernel
+  * constant trend / mean, estimated
+  * interpolation (no nugget beyond numerical jitter)
+  * hyperparameters by maximum likelihood, package defaults for the optimizer
+
+Each fit runs in a subprocess with a wall-clock budget (--budget, default
+300 s); failures and timeouts are recorded, never fatal.
+
+Output: results/python.csv with columns
+  func,d,n,rep,package,fit_time,pred_time,rmse,q2,nlpd,status
+"""
+import argparse
+import glob
+import multiprocessing as mp
+import os
+import time
+import traceback
+
+import numpy as np
+
+JITTER = 1e-10
+
+
+# ----------------------------------------------------------------- adapters
+def fit_pylibkriging(X, y):
+    import pylibkriging as lk
+    t0 = time.perf_counter()
+    m = lk.Kriging(y, X, "matern5_2", "constant", False, "BFGS", "LL")
+    return m, time.perf_counter() - t0
+
+
+def pred_pylibkriging(m, Xt):
+    p = m.predict(Xt, True, False, False)
+    return np.asarray(p[0]).ravel(), np.asarray(p[1]).ravel()
+
+
+def fit_sklearn(X, y):
+    from sklearn.gaussian_process import GaussianProcessRegressor
+    from sklearn.gaussian_process.kernels import ConstantKernel, Matern
+    k = ConstantKernel(1.0, (1e-5, 1e7)) * Matern(
+        length_scale=np.ones(X.shape[1]),
+        length_scale_bounds=(1e-6, 1e6), nu=2.5)
+    t0 = time.perf_counter()
+    m = GaussianProcessRegressor(kernel=k, alpha=JITTER, normalize_y=True,
+                                 n_restarts_optimizer=0).fit(X, y)
+    return m, time.perf_counter() - t0
+
+
+def pred_sklearn(m, Xt):
+    mu, sd = m.predict(Xt, return_std=True)
+    return mu.ravel(), sd.ravel()
+
+
+def fit_gpy(X, y):
+    import GPy
+    k = GPy.kern.Matern52(input_dim=X.shape[1], ARD=True)
+    t0 = time.perf_counter()
+    m = GPy.models.GPRegression(X, y.reshape(-1, 1), k)
+    m.Gaussian_noise.variance = JITTER
+    m.Gaussian_noise.variance.fix()
+    m.optimize()
+    return m, time.perf_counter() - t0
+
+
+def pred_gpy(m, Xt):
+    mu, var = m.predict(Xt, include_likelihood=False)
+    return mu.ravel(), np.sqrt(np.maximum(var.ravel(), 0))
+
+
+def fit_smt(X, y):
+    from smt.surrogate_models import KRG
+    t0 = time.perf_counter()
+    m = KRG(corr="matern52", theta0=[1e-2] * X.shape[1],
+            print_global=False)
+    m.set_training_values(X, y)
+    m.train()
+    return m, time.perf_counter() - t0
+
+
+def pred_smt(m, Xt):
+    mu = m.predict_values(Xt).ravel()
+    var = m.predict_variances(Xt).ravel()
+    return mu, np.sqrt(np.maximum(var, 0))
+
+
+def fit_openturns(X, y):
+    import openturns as ot
+    d = X.shape[1]
+    t0 = time.perf_counter()
+    cov = ot.MaternModel([1.0] * d, [1.0], 2.5)
+    basis = ot.ConstantBasisFactory(d).build()
+    algo = ot.KrigingAlgorithm(ot.Sample(X), ot.Sample(y.reshape(-1, 1)),
+                               cov, basis)
+    algo.run()
+    return algo.getResult(), time.perf_counter() - t0
+
+
+def pred_openturns(res, Xt):
+    import openturns as ot
+    meta = res.getMetaModel()
+    mu = np.asarray(meta(ot.Sample(Xt))).ravel()
+    var = np.asarray(
+        res.getConditionalMarginalVariance(ot.Sample(Xt))).ravel()
+    return mu, np.sqrt(np.maximum(var, 0))
+
+
+PACKAGES = {
+    "pylibkriging": (fit_pylibkriging, pred_pylibkriging),
+    "sklearn": (fit_sklearn, pred_sklearn),
+    "GPy": (fit_gpy, pred_gpy),
+    "SMT": (fit_smt, pred_smt),
+    "OpenTURNS": (fit_openturns, pred_openturns),
+}
+
+
+# ----------------------------------------------------------------- harness
+def metrics(y, mu, sd):
+    rmse = float(np.sqrt(np.mean((y - mu) ** 2)))
+    q2 = float(1 - np.sum((y - mu) ** 2) / np.sum((y - np.mean(y)) ** 2))
+    s2 = np.maximum(sd, 1e-12) ** 2
+    nlpd = float(np.mean(0.5 * np.log(2 * np.pi * s2)
+                         + 0.5 * (y - mu) ** 2 / s2))
+    return rmse, q2, nlpd
+
+
+def one_task(pkg, paths, queue):
+    try:
+        X = np.loadtxt(paths["X_train"], delimiter=",", ndmin=2)
+        y = np.loadtxt(paths["y_train"], delimiter=",")
+        Xt = np.loadtxt(paths["X_test"], delimiter=",", ndmin=2)
+        yt = np.loadtxt(paths["y_test"], delimiter=",")
+        fit, pred = PACKAGES[pkg]
+        model, fit_time = fit(X, y)
+        t0 = time.perf_counter()
+        mu, sd = pred(model, Xt)
+        pred_time = time.perf_counter() - t0
+        rmse, q2, nlpd = metrics(yt, mu, sd)
+        queue.put((fit_time, pred_time, rmse, q2, nlpd, "ok"))
+    except Exception:
+        traceback.print_exc()
+        queue.put((np.nan,) * 5 + ("error",))
+
+
+def run_with_budget(pkg, paths, budget):
+    queue = mp.Queue()
+    p = mp.Process(target=one_task, args=(pkg, paths, queue))
+    p.start()
+    p.join(budget)
+    if p.is_alive():
+        p.terminate()
+        p.join()
+        return (np.nan,) * 5 + ("timeout",)
+    return queue.get() if not queue.empty() else (np.nan,) * 5 + ("crash",)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", default="data")
+    ap.add_argument("--out", default="results/python.csv")
+    ap.add_argument("--budget", type=float, default=300.0)
+    ap.add_argument("--packages", default=",".join(PACKAGES))
+    args = ap.parse_args()
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    rows = ["func,d,n,rep,package,fit_time,pred_time,rmse,q2,nlpd,status"]
+    for xtr in sorted(glob.glob(
+            os.path.join(args.data, "*", "n*", "rep*", "X_train.csv"))):
+        rdir = os.path.dirname(xtr)
+        ndir = os.path.dirname(rdir)
+        fdir = os.path.dirname(ndir)
+        func = os.path.basename(fdir)
+        n = int(os.path.basename(ndir)[1:])
+        rep = int(os.path.basename(rdir)[3:])
+        paths = {"X_train": xtr,
+                 "y_train": os.path.join(rdir, "y_train.csv"),
+                 "X_test": os.path.join(fdir, "X_test.csv"),
+                 "y_test": os.path.join(fdir, "y_test.csv")}
+        d = np.loadtxt(xtr, delimiter=",", ndmin=2).shape[1]
+        for pkg in args.packages.split(","):
+            res = run_with_budget(pkg, paths, args.budget)
+            rows.append(f"{func},{d},{n},{rep},{pkg},"
+                        + ",".join(str(v) for v in res))
+            print(rows[-1], flush=True)
+    with open(args.out, "w") as fh:
+        fh.write("\n".join(rows) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/comparison/run_r.R
+++ b/bench/comparison/run_r.R
@@ -1,0 +1,97 @@
+#!/usr/bin/env Rscript
+# Benchmark rlibkriging against DiceKriging and RobustGaSP on the shared
+# datasets produced by make_datasets.py (identical designs as the Python run).
+#
+# Common modelling choices: Matern 5/2 ARD kernel, constant trend,
+# interpolation (no nugget), hyperparameters by MLE (package defaults).
+# Per-fit wall-clock budget via setTimeLimit (default 300 s).
+#
+# Usage: Rscript run_r.R [data_dir] [out_csv] [budget_seconds]
+
+args <- commandArgs(trailingOnly = TRUE)
+data_dir <- ifelse(length(args) >= 1, args[1], "data")
+out_csv  <- ifelse(length(args) >= 2, args[2], "results/r.csv")
+budget   <- ifelse(length(args) >= 3, as.numeric(args[3]), 300)
+
+dir.create(dirname(out_csv), recursive = TRUE, showWarnings = FALSE)
+
+read_mat <- function(p) as.matrix(read.csv(p, header = FALSE))
+read_vec <- function(p) as.numeric(read.csv(p, header = FALSE)[[1]])
+
+fitters <- list(
+  rlibkriging = list(
+    fit = function(X, y) rlibkriging::Kriging(
+      y, X, kernel = "matern5_2", regmodel = "constant", objective = "LL"),
+    pred = function(m, Xt) {
+      p <- rlibkriging::predict(m, Xt, return_stdev = TRUE)
+      list(mu = as.numeric(p$mean), sd = as.numeric(p$stdev))
+    }),
+  DiceKriging = list(
+    fit = function(X, y) DiceKriging::km(
+      formula = ~1, design = X, response = y, covtype = "matern5_2",
+      nugget.estim = FALSE, control = list(trace = FALSE)),
+    pred = function(m, Xt) {
+      p <- DiceKriging::predict(m, newdata = Xt, type = "UK",
+                                se.compute = TRUE, checkNames = FALSE)
+      list(mu = p$mean, sd = p$sd)
+    }),
+  RobustGaSP = list(
+    fit = function(X, y) RobustGaSP::rgasp(
+      design = X, response = y, kernel_type = "matern_5_2"),
+    pred = function(m, Xt) {
+      p <- RobustGaSP::predict(m, Xt)
+      list(mu = p$mean, sd = p$sd)
+    })
+)
+
+metrics <- function(y, mu, sd) {
+  rmse <- sqrt(mean((y - mu)^2))
+  q2 <- 1 - sum((y - mu)^2) / sum((y - mean(y))^2)
+  s2 <- pmax(sd, 1e-12)^2
+  nlpd <- mean(0.5 * log(2 * pi * s2) + 0.5 * (y - mu)^2 / s2)
+  c(rmse = rmse, q2 = q2, nlpd = nlpd)
+}
+
+rows <- c("func,d,n,rep,package,fit_time,pred_time,rmse,q2,nlpd,status")
+
+for (xtr in sort(Sys.glob(file.path(data_dir, "*", "n*", "rep*", "X_train.csv")))) {
+  rdir <- dirname(xtr); ndir <- dirname(rdir); fdir <- dirname(ndir)
+  func <- basename(fdir)
+  n <- as.integer(sub("^n", "", basename(ndir)))
+  rep <- as.integer(sub("^rep", "", basename(rdir)))
+  X  <- read_mat(xtr)
+  y  <- read_vec(file.path(rdir, "y_train.csv"))
+  Xt <- read_mat(file.path(fdir, "X_test.csv"))
+  yt <- read_vec(file.path(fdir, "y_test.csv"))
+  d <- ncol(X)
+  colnames(X) <- colnames(Xt) <- paste0("x", seq_len(d))
+
+  for (pkg in names(fitters)) {
+    fit_time <- pred_time <- rmse <- q2 <- nlpd <- NA
+    status <- "ok"
+    res <- tryCatch({
+      setTimeLimit(elapsed = budget, transient = TRUE)
+      t0 <- proc.time()[["elapsed"]]
+      m <- fitters[[pkg]]$fit(X, y)
+      fit_time <- proc.time()[["elapsed"]] - t0
+      t0 <- proc.time()[["elapsed"]]
+      p <- fitters[[pkg]]$pred(m, Xt)
+      pred_time <- proc.time()[["elapsed"]] - t0
+      setTimeLimit(elapsed = Inf)
+      metrics(yt, p$mu, p$sd)
+    }, error = function(e) {
+      setTimeLimit(elapsed = Inf)
+      status <<- if (grepl("time limit", conditionMessage(e))) "timeout" else "error"
+      message(sprintf("[%s %s n=%d rep=%d] %s", pkg, func, n, rep,
+                      conditionMessage(e)))
+      c(rmse = NA, q2 = NA, nlpd = NA)
+    })
+    rows <- c(rows, sprintf("%s,%d,%d,%d,%s,%s,%s,%s,%s,%s,%s",
+                            func, d, n, rep, pkg,
+                            fit_time, pred_time,
+                            res[["rmse"]], res[["q2"]], res[["nlpd"]], status))
+    cat(tail(rows, 1), "\n")
+  }
+}
+
+writeLines(rows, out_csv)


### PR DESCRIPTION
# Cross-package comparison benchmark on shared randomized LHS designs

## What

Adds `bench/comparison/` and a dedicated CI workflow benchmarking libKriging
against classic kriging packages, in both ecosystems:

| | Packages |
|---|---|
| Python | **pylibkriging**, scikit-learn, GPy, SMT, OpenTURNS |
| R | **rlibkriging**, DiceKriging, RobustGaSP |

## Protocol

- **Response surfaces**: Branin (d=2), Hartmann-3, Hartmann-6, Borehole (d=8),
  training sizes 50 → 1000 points.
- **Identical designs everywhere**: LHS designs (scipy `qmc`, deterministic
  seed per `(n, rep)`), **10 randomized repetitions** per case, plus a common
  2000-point test set per function. Designs are generated once
  (`make_datasets.py`), written to CSV, and consumed as-is by the Python and R
  runners — every package is conditioned on exactly the same points.
- **Common model settings**: Matern 5/2 anisotropic kernel, constant trend,
  interpolation (no nugget), MLE with each package's default optimizer.
- **Metrics**: fit time, prediction time, RMSE, Q², NLPD; per-fit wall-clock
  budget (default 300 s) with timeouts/errors recorded, never fatal.
- **Report**: median [q25; q75] over repetitions per (function, n), published
  to `$GITHUB_STEP_SUMMARY` and uploaded as artifact (`summary.md`,
  `all.csv`).

## CI

`.github/workflows/bench-comparison.yml`: manual `workflow_dispatch`
(inputs: `repeats`, `quick`, `budget`) + monthly schedule; never on push/PR.
Jobs: `datasets` → (`bench-python`, `bench-r`, both consuming the same
artifact) → `report`. Python pinned to 3.11 / `numpy<2` for GPy.

## Testing done

- Test functions validated against known optima (Branin 0.3979,
  Hartmann-3 −3.8628, Hartmann-6 −3.3224).
- Full chain (datasets → run_python → aggregate) executed locally in quick
  mode with pylibkriging + scikit-learn: report generated as expected.

## Notes for reviewers

- `run_r.R` syntax could not be checked in my environment (no Rscript) —
  covered by the CI run.
- Please double-check the `pylibkriging.Kriging(...)` constructor call and
  `predict` return layout against the 1.1 API.
- Fairness caveats (default optimizers/bounds differ across packages) are
  documented in `bench/comparison/README.md` and repeated in the generated
  report; refinements welcome, kept symmetric across packages.
