### PR TITLE
docs: update CHANGELOG and READMEs for changes since v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ past release, see the corresponding entry on the
 
 ## [Unreleased]
 
+### Added
+- Python: scikit-learn compatible estimators for all four Kriging classes —
+  `KrigingRegressor`, `WarpKrigingRegressor`, `MLPKrigingRegressor`,
+  `NestedKrigingRegressor` in `pylibkriging.sklearn`, implementing the
+  scikit-learn estimator API (`fit`/`predict`, `get_params`/`set_params`,
+  `clone`) so they drop into `Pipeline` and `GridSearchCV` (#338).
+- Cross-package comparison benchmark (`bench/comparison/`): libKriging vs.
+  scikit-learn/GPy/SMT/OpenTURNS (Python) and DiceKriging/RobustGaSP (R) on
+  shared randomized LHS designs (Branin, Hartmann-3/6, Borehole), reporting
+  fit/predict time, RMSE, Q², NLPD; runs on a manual/monthly CI workflow (#335).
+
+### Changed
+- Python: dropped the `numpy<2` pin — `pylibkriging` now supports NumPy 2.x.
+  Required bumping the vendored `pybind11` (2.10.1 → 2.13.6) and `carma`
+  submodules, since both hardcode offsets into NumPy's C-API function table
+  and predated the NumPy 2.0 ABI changes; also fixed a bug in carma's own
+  NumPy-2.0 fix where `PyArray_CopyInto`'s table offset (which differs
+  between NumPy 1.x and 2.x) was hardcoded to the NumPy-2-only value instead
+  of being picked at runtime (#339, libKriging/carma#1).
+
+### Fixed
+- R: `.match_kriging_objective`'s internal validator no longer hijacks
+  `Kriging`'s roxygen `@export` documentation (#329).
+- Python: `loading_test`'s version check no longer hardcodes the expected
+  version, reading it from `cmake/version.cmake` instead so it doesn't need
+  updating on every release (#328).
+- CI: Windows jobs retry the `choco install` step to absorb transient
+  community-feed 504s (#326); `rlibkriging`'s `tools/gitmodules-shas` is kept
+  in sync with submodule bumps, staged in the right order (#330, #331).
+
+### Documentation
+- Added a coding-agent skill covering libKriging usage patterns (#336) and a
+  "Known pitfalls" section to `AGENTS.md` (#333).
+
+### CI/Release process
+- Automated `jlibkriging` registration on Julia's General registry (#332).
+- GitHub release notes are now filled in from this changelog (#334).
+
 ## [1.1.0] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Many bindings are available to use 'libKriging' from Python, R, Octave, Matlab a
 - **Input warpings**: boxcox, kumaraswamy, knots, mlp, categorical, ordinal.
 - **Operations**: fit, predict, simulate, update, save/load, and cross-language model exchange.
 - **Bindings**: Python, R, Octave, Matlab, Julia — see [bindings/README.md](bindings/README.md) for the full method reference.
+- **Python**: scikit-learn compatible estimators (`pylibkriging.sklearn`) for all four Kriging classes, usable in `Pipeline`/`GridSearchCV`.
 
 
 Table of contents

--- a/bindings/Python/README.md
+++ b/bindings/Python/README.md
@@ -91,6 +91,26 @@ p = k.predict(x, True, False)
 
 Full demo: [tests/pylibkriging_demo.py](pylibkriging/tests/pylibkriging_demo.py)
 
+## scikit-learn compatible estimators
+
+`pylibkriging.sklearn` exposes `KrigingRegressor`, `WarpKrigingRegressor`,
+`MLPKrigingRegressor` and `NestedKrigingRegressor`, implementing the
+scikit-learn estimator API (`fit`/`predict`, `get_params`/`set_params`,
+`clone`), so they drop into `Pipeline` and `GridSearchCV`:
+
+```python
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from pylibkriging.sklearn import KrigingRegressor
+
+pipe = Pipeline([
+    ("scale", StandardScaler()),
+    ("krige", KrigingRegressor(kernel="matern5_2")),
+]).fit(X_train, y_train)
+
+pred, stdev = pipe.predict(X_test, return_std=True)
+```
+
 ## CI
 
 Tested in GitHub Actions (`main.yml`):


### PR DESCRIPTION
## Summary
Fills in the (previously empty) `[Unreleased]` section of `CHANGELOG.md` with everything merged since the v1.1.0 tag (2026-07-08):
- scikit-learn compatible Python estimators (#338)
- cross-package comparison benchmark (#335)
- numpy<2 pin removal / pybind11+carma upgrade (#339, libKriging/carma#1)
- R roxygen fix (#329), Python loading_test fix (#328), CI fixes (#326, #330, #331)
- docs additions (#333, #336) and release-process automation (#332, #334)

Also documents the new scikit-learn estimators in `bindings/Python/README.md` (short usage example) and adds a one-line mention to the main `README.md` feature list.

## Test plan
- [ ] Docs-only change, no code/build impact — CI guideline checks only