### PR TITLE
fix(bench): data-range-aware length-scale init for GPy/sklearn/OpenTURNS

### DIFF
--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         # One package per job so the (func x n x rep) sweep runs in parallel
         # across packages instead of sequentially in a single 6h+ job.
-        package: [pylibkriging, sklearn, GPy, SMT, OpenTURNS]
+        package: [pylibkriging, sklearn, GPy, SMT, OpenTURNS, GPyTorch]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -76,6 +76,8 @@ jobs:
             GPy)          pip install GPy ;;
             SMT)          pip install smt ;;
             OpenTURNS)    pip install openturns ;;
+            GPyTorch)     pip install torch --index-url https://download.pytorch.org/whl/cpu
+                          pip install gpytorch ;;
           esac
       - uses: actions/download-artifact@v4
         with:
@@ -93,33 +95,61 @@ jobs:
           path: bench/comparison/results
 
   bench-r:
-    name: R packages
+    name: R packages (${{ matrix.package }})
     needs: datasets
     runs-on: ubuntu-22.04
-    timeout-minutes: 720
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        # One package per job, same rationale as bench-python above.
+        package: [rlibkriging, DiceKriging, RobustGaSP]
     steps:
       - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-      - name: Install R packages
-        run: |
-          Rscript -e 'install.packages(c("rlibkriging", "DiceKriging", "RobustGaSP"))'
+      - name: Install ${{ matrix.package }}
+        run: Rscript -e 'install.packages("${{ matrix.package }}")'
       - uses: actions/download-artifact@v4
         with:
           name: bench-datasets
           path: bench/comparison/data
-      - name: Run R benchmark
+      - name: Run R benchmark (${{ matrix.package }})
         working-directory: bench/comparison
-        run: Rscript run_r.R data results/r.csv "$BUDGET"
+        run: |
+          Rscript run_r.R data "results/r-${{ matrix.package }}.csv" "$BUDGET" "${{ matrix.package }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: bench-results-r
+          name: bench-results-r-${{ matrix.package }}
+          path: bench/comparison/results
+
+  bench-stk:
+    name: STK (Octave)
+    needs: datasets
+    runs-on: ubuntu-22.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Octave
+        run: sudo apt-get update -qy && sudo apt-get install -qy octave
+      - name: Clone STK
+        run: git clone --depth 1 https://github.com/stk-kriging/stk.git "$RUNNER_TEMP/stk"
+      - uses: actions/download-artifact@v4
+        with:
+          name: bench-datasets
+          path: bench/comparison/data
+      - name: Run STK benchmark
+        working-directory: bench/comparison
+        run: octave --no-gui run_stk.m "$RUNNER_TEMP/stk" data results/stk.csv
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-stk
           path: bench/comparison/results
 
   report:
     name: Aggregate report
-    needs: [datasets, bench-python, bench-r]
+    needs: [datasets, bench-python, bench-r, bench-stk]
     if: always() && needs.datasets.result == 'success'
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -1,18 +1,13 @@
 name: Comparison benchmark
 
 # Cross-package kriging benchmark on shared LHS designs.
-# Heavy job: manual trigger + monthly schedule, never on push/PR.
-# TEMPORARY: also run on push to this PR's branch so the scaling/restarts fix
-# to run_python.py gets exercised by CI before merge. Remove the
-# `fix/comparison-benchmark-scaling` entry below once verified.
-# (NOTE: `feature/comparison-benchmark` below is a leftover from the same
-# kind of temporary trigger added for the PR that introduced this workflow,
-# never cleaned up after merge — and its `pull_request:` counterpart never
-# actually fired, since that PR's base branch was `master`, not itself.
-# Safe to drop `feature/comparison-benchmark` here too whenever convenient.)
+# Heavy job: manual trigger, monthly schedule, push to master, or push of a
+# `bench*` tag. Never runs automatically on a regular push/PR to other branches.
 on:
   push:
-    branches: [feature/comparison-benchmark, fix/comparison-benchmark-scaling]
+    branches: [master]
+    tags:
+      - 'bench*'
   workflow_dispatch:
     inputs:
       repeats:

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -132,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Octave
-        run: sudo apt-get update -qy && sudo apt-get install -qy octave
+        run: sudo apt-get update -qy && sudo apt-get install -qy octave liboctave-dev
       - name: Clone STK
         run: git clone --depth 1 https://github.com/stk-kriging/stk.git "$RUNNER_TEMP/stk"
       - uses: actions/download-artifact@v4

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -2,13 +2,17 @@ name: Comparison benchmark
 
 # Cross-package kriging benchmark on shared LHS designs.
 # Heavy job: manual trigger + monthly schedule, never on push/PR.
-# TEMPORARY: also run on this PR's branch so the new benchmark gets exercised
-# by CI before merge. Remove the push/pull_request triggers below once verified.
+# TEMPORARY: also run on push to this PR's branch so the scaling/restarts fix
+# to run_python.py gets exercised by CI before merge. Remove the
+# `fix/comparison-benchmark-scaling` entry below once verified.
+# (NOTE: `feature/comparison-benchmark` below is a leftover from the same
+# kind of temporary trigger added for the PR that introduced this workflow,
+# never cleaned up after merge — and its `pull_request:` counterpart never
+# actually fired, since that PR's base branch was `master`, not itself.
+# Safe to drop `feature/comparison-benchmark` here too whenever convenient.)
 on:
   push:
-    branches: [feature/comparison-benchmark]
-  pull_request:
-    branches: [feature/comparison-benchmark]
+    branches: [feature/comparison-benchmark, fix/comparison-benchmark-scaling]
   workflow_dispatch:
     inputs:
       repeats:

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -52,26 +52,44 @@ jobs:
           path: bench/comparison/data
 
   bench-python:
-    name: Python packages
+    name: Python packages (${{ matrix.package }})
     needs: datasets
     runs-on: ubuntu-22.04
-    timeout-minutes: 720
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        # One package per job so the (func x n x rep) sweep runs in parallel
+        # across packages instead of sequentially in a single 6h+ job.
+        package: [pylibkriging, sklearn, GPy, SMT, OpenTURNS]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'  # GPy compatibility
-      - run: pip install "numpy<2" scipy pandas pylibkriging scikit-learn GPy smt openturns
+      - name: Install ${{ matrix.package }}
+        run: |
+          pip install "numpy<2" scipy pandas
+          case "${{ matrix.package }}" in
+            pylibkriging) pip install pylibkriging ;;
+            sklearn)      pip install scikit-learn ;;
+            GPy)          pip install GPy ;;
+            SMT)          pip install smt ;;
+            OpenTURNS)    pip install openturns ;;
+          esac
       - uses: actions/download-artifact@v4
         with:
           name: bench-datasets
           path: bench/comparison/data
-      - name: Run Python benchmark
+      - name: Run Python benchmark (${{ matrix.package }})
         working-directory: bench/comparison
-        run: python run_python.py --budget "$BUDGET" --out results/python.csv
+        run: |
+          python run_python.py --budget "$BUDGET" \
+            --packages "${{ matrix.package }}" \
+            --out "results/python-${{ matrix.package }}.csv"
       - uses: actions/upload-artifact@v4
         with:
-          name: bench-results-python
+          name: bench-results-python-${{ matrix.package }}
           path: bench/comparison/results
 
   bench-r:

--- a/bench/comparison/README.md
+++ b/bench/comparison/README.md
@@ -2,12 +2,13 @@
 
 Benchmarks libKriging (`pylibkriging`, `rlibkriging`) against classic kriging
 packages on standard response surfaces, with **identical, randomized designs**
-shared across all packages and both languages.
+shared across all packages and languages.
 
 | | Packages |
 |---|---|
-| Python | pylibkriging, scikit-learn, GPy, SMT, OpenTURNS |
+| Python | pylibkriging, scikit-learn, GPy, GPyTorch, SMT, OpenTURNS |
 | R | rlibkriging, DiceKriging, RobustGaSP |
+| Octave | [STK](https://github.com/stk-kriging/stk) |
 
 ## Protocol
 
@@ -30,19 +31,27 @@ shared across all packages and both languages.
 
 ```sh
 cd bench/comparison
-pip install "numpy<2" scipy pandas pylibkriging scikit-learn GPy smt openturns
+pip install "numpy<2" scipy pandas pylibkriging scikit-learn GPy smt openturns torch gpytorch
 python make_datasets.py --repeats 10          # or --quick
-python run_python.py                          # results/python.csv
+python run_python.py                          # results/python.csv, all Python packages
 Rscript run_r.R data results/r.csv 300        # needs rlibkriging, DiceKriging, RobustGaSP
+octave run_stk.m /path/to/stk data results/stk.csv  # needs a local clone of stk-kriging/stk
 python aggregate.py                           # results/all.csv + summary.md
 ```
+
+`--packages` (Python) / a 4th CLI arg (R) restrict a run to a subset,
+e.g. `python run_python.py --packages GPyTorch` or
+`Rscript run_r.R data results/r.csv 300 DiceKriging`.
 
 ## CI
 
 `.github/workflows/bench-comparison.yml` — manual `workflow_dispatch`
 (inputs: `repeats`, `quick`, `budget`) plus a monthly schedule. It never runs
 on push/PR (too heavy). Python is pinned to 3.11 and `numpy<2` for GPy
-compatibility.
+compatibility. Each Python and R package, plus STK, runs in its own parallel
+job (one process per package) rather than one sequential job per language —
+the full func x n x rep sweep for a single heavy package already pushes
+against CI job timeouts, let alone all of them one after another.
 
 ## Fairness caveats
 

--- a/bench/comparison/README.md
+++ b/bench/comparison/README.md
@@ -50,3 +50,14 @@ Packages differ in optimizer, restarts, bounds and internal rescaling; this
 compares *default MLE fits* under a common kernel/trend, not tuned setups.
 Contributions refining per-package settings are welcome — please keep any
 change symmetric across packages.
+
+pylibkriging/DiceKriging/RobustGaSP derive their correlation-length search
+range from the actual data by default. GPy, scikit-learn and OpenTURNS
+don't, so `run_python.py` derives a data-range-aware initial length-scale
+and bounds for those three (see its module docstring) — without it, they
+silently degenerate to a near-constant predictor on `borehole` (raw
+physical units spanning 5+ orders of magnitude across dimensions) and, for
+scikit-learn specifically, on the `hartmann` functions too (short
+correlation length vs. its zero-restart default). This is a fit-quality
+fix, not a change of kernel/trend/objective — it targets the same "fair
+MLE fit" this benchmark aims for, not a tuned/best-case setup.

--- a/bench/comparison/run_python.py
+++ b/bench/comparison/run_python.py
@@ -5,7 +5,22 @@ Common modelling choices (as close as each API allows):
   * Matern 5/2 anisotropic (ARD) kernel
   * constant trend / mean, estimated
   * interpolation (no nugget beyond numerical jitter)
-  * hyperparameters by maximum likelihood, package defaults for the optimizer
+  * hyperparameters by maximum likelihood
+
+pylibkriging/DiceKriging/RobustGaSP derive their correlation-length search
+range from the actual data (either internally, or because their default
+optimizer bounds are computed from the input range), so they cope with
+both normalized ([0,1]^d) and raw-physical-unit domains (e.g. `borehole`,
+whose 8 dimensions span 5+ orders of magnitude) out of the box. GPy,
+scikit-learn and OpenTURNS don't: left at their literal defaults
+(length_scale/theta0 = 1 in the *raw* input units, single-start
+optimization), they silently converge to a near-constant predictor
+whenever the data isn't already O(1)-scaled or has short correlation
+lengths relative to that. `_length_scale_init` derives a data-range-aware
+initial guess/bounds for these three so the comparison reflects each
+package's actual fitting quality rather than a scale mismatch; sklearn
+also gets a few optimizer restarts (`n_restarts_optimizer=0`, sklearn's
+own default, is a well-known trap for multimodal likelihoods).
 
 Each fit runs in a subprocess with a wall-clock budget (--budget, default
 300 s); failures and timeouts are recorded, never fatal.
@@ -23,6 +38,17 @@ import traceback
 import numpy as np
 
 JITTER = 1e-10
+N_RESTARTS = 5
+
+
+def _length_scale_init(X):
+    """Per-dimension (init, lower, upper) for an ARD length-scale, derived
+    from the actual column range so a length_scale=1 default doesn't
+    silently degenerate on non-O(1)-scaled or short-correlation-length
+    domains (see module docstring)."""
+    rng = X.max(axis=0) - X.min(axis=0)
+    rng = np.where(rng > 0, rng, 1.0)
+    return rng * 0.1, rng * 1e-4, rng * 1e2
 
 
 # ----------------------------------------------------------------- adapters
@@ -41,12 +67,13 @@ def pred_pylibkriging(m, Xt):
 def fit_sklearn(X, y):
     from sklearn.gaussian_process import GaussianProcessRegressor
     from sklearn.gaussian_process.kernels import ConstantKernel, Matern
+    init, lo, hi = _length_scale_init(X)
     k = ConstantKernel(1.0, (1e-5, 1e7)) * Matern(
-        length_scale=np.ones(X.shape[1]),
-        length_scale_bounds=(1e-6, 1e6), nu=2.5)
+        length_scale=init,
+        length_scale_bounds=list(zip(lo, hi)), nu=2.5)
     t0 = time.perf_counter()
     m = GaussianProcessRegressor(kernel=k, alpha=JITTER, normalize_y=True,
-                                 n_restarts_optimizer=0).fit(X, y)
+                                 n_restarts_optimizer=N_RESTARTS).fit(X, y)
     return m, time.perf_counter() - t0
 
 
@@ -57,12 +84,16 @@ def pred_sklearn(m, Xt):
 
 def fit_gpy(X, y):
     import GPy
-    k = GPy.kern.Matern52(input_dim=X.shape[1], ARD=True)
+    init, lo, hi = _length_scale_init(X)
+    k = GPy.kern.Matern52(input_dim=X.shape[1], ARD=True, lengthscale=init)
+    for i in range(X.shape[1]):
+        k.lengthscale[i:i + 1].constrain_bounded(lo[i], hi[i], warning=False)
     t0 = time.perf_counter()
     m = GPy.models.GPRegression(X, y.reshape(-1, 1), k)
     m.Gaussian_noise.variance = JITTER
     m.Gaussian_noise.variance.fix()
-    m.optimize()
+    m.optimize_restarts(num_restarts=N_RESTARTS, verbose=False,
+                         robust=True)
     return m, time.perf_counter() - t0
 
 
@@ -90,11 +121,17 @@ def pred_smt(m, Xt):
 def fit_openturns(X, y):
     import openturns as ot
     d = X.shape[1]
+    init, lo, hi = _length_scale_init(X)
     t0 = time.perf_counter()
-    cov = ot.MaternModel([1.0] * d, [1.0], 2.5)
+    cov = ot.MaternModel(list(init), [1.0], 2.5)
     basis = ot.ConstantBasisFactory(d).build()
     algo = ot.KrigingAlgorithm(ot.Sample(X), ot.Sample(y.reshape(-1, 1)),
                                cov, basis)
+    try:
+        algo.setOptimizationBounds(ot.Interval(list(lo), list(hi)))
+    except Exception:
+        pass  # OT version optimizes a different parameter count; keep the
+              # corrected initial scale, which is the dominant fix.
     algo.run()
     return algo.getResult(), time.perf_counter() - t0
 

--- a/bench/comparison/run_python.py
+++ b/bench/comparison/run_python.py
@@ -1,5 +1,5 @@
-"""Benchmark pylibkriging against GPy, scikit-learn, SMT and OpenTURNS on the
-shared datasets produced by make_datasets.py.
+"""Benchmark pylibkriging against GPy, scikit-learn, GPyTorch, SMT and
+OpenTURNS on the shared datasets produced by make_datasets.py.
 
 Common modelling choices (as close as each API allows):
   * Matern 5/2 anisotropic (ARD) kernel
@@ -12,15 +12,15 @@ range from the actual data (either internally, or because their default
 optimizer bounds are computed from the input range), so they cope with
 both normalized ([0,1]^d) and raw-physical-unit domains (e.g. `borehole`,
 whose 8 dimensions span 5+ orders of magnitude) out of the box. GPy,
-scikit-learn and OpenTURNS don't: left at their literal defaults
+scikit-learn, OpenTURNS and GPyTorch don't: left at their literal defaults
 (length_scale/theta0 = 1 in the *raw* input units, single-start
 optimization), they silently converge to a near-constant predictor
 whenever the data isn't already O(1)-scaled or has short correlation
 lengths relative to that. `_length_scale_init` derives a data-range-aware
-initial guess/bounds for these three so the comparison reflects each
-package's actual fitting quality rather than a scale mismatch; sklearn
-also gets a few optimizer restarts (`n_restarts_optimizer=0`, sklearn's
-own default, is a well-known trap for multimodal likelihoods).
+initial guess/bounds for these four so the comparison reflects each
+package's actual fitting quality rather than a scale mismatch; sklearn,
+GPy and GPyTorch also get a few optimizer restarts (`n_restarts_optimizer=0`,
+sklearn's own default, is a well-known trap for multimodal likelihoods).
 
 Each fit runs in a subprocess with a wall-clock budget (--budget, default
 300 s); failures and timeouts are recorded, never fatal.
@@ -145,12 +145,77 @@ def pred_openturns(res, Xt):
     return mu, np.sqrt(np.maximum(var, 0))
 
 
+def fit_gpytorch(X, y):
+    import torch
+    import gpytorch
+
+    init, lo, hi = _length_scale_init(X)
+    train_x = torch.tensor(X, dtype=torch.float64)
+    train_y = torch.tensor(y, dtype=torch.float64)
+
+    class ExactGPModel(gpytorch.models.ExactGP):
+        def __init__(self, train_x, train_y, likelihood):
+            super().__init__(train_x, train_y, likelihood)
+            self.mean_module = gpytorch.means.ConstantMean()
+            self.covar_module = gpytorch.kernels.ScaleKernel(
+                gpytorch.kernels.MaternKernel(
+                    nu=2.5, ard_num_dims=train_x.shape[1]))
+
+        def forward(self, x):
+            return gpytorch.distributions.MultivariateNormal(
+                self.mean_module(x), self.covar_module(x))
+
+    likelihood = gpytorch.likelihoods.GaussianLikelihood()
+    likelihood.noise = JITTER
+    likelihood.noise_covar.raw_noise.requires_grad_(False)
+    model = ExactGPModel(train_x, train_y, likelihood)
+    mll = gpytorch.mlls.ExactMarginalLogLikelihood(likelihood, model)
+
+    t0 = time.perf_counter()
+    model.train()
+    likelihood.train()
+    best_loss, best_state = float("inf"), None
+    for restart in range(N_RESTARTS):
+        # Same data-range-aware init as sklearn/GPy/OpenTURNS (see module
+        # docstring); random within (lo, hi) on restarts > 0.
+        start = init if restart == 0 else lo + np.random.rand(len(init)) * (hi - lo)
+        with torch.no_grad():
+            model.covar_module.base_kernel.lengthscale = torch.tensor(
+                start, dtype=torch.float64)
+            model.covar_module.outputscale = torch.tensor(1.0, dtype=torch.float64)
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+        loss = None
+        for _ in range(100):
+            optimizer.zero_grad()
+            loss = -mll(model(train_x), train_y)
+            loss.backward()
+            optimizer.step()
+        if loss.item() < best_loss:
+            best_loss = loss.item()
+            best_state = {k: v.clone() for k, v in model.state_dict().items()}
+    model.load_state_dict(best_state)
+    return (model, likelihood), time.perf_counter() - t0
+
+
+def pred_gpytorch(m, Xt):
+    import torch
+    import gpytorch
+    model, likelihood = m
+    model.eval()
+    likelihood.eval()
+    test_x = torch.tensor(Xt, dtype=torch.float64)
+    with torch.no_grad(), gpytorch.settings.fast_pred_var():
+        pred = likelihood(model(test_x))
+    return pred.mean.numpy(), pred.stddev.numpy()
+
+
 PACKAGES = {
     "pylibkriging": (fit_pylibkriging, pred_pylibkriging),
     "sklearn": (fit_sklearn, pred_sklearn),
     "GPy": (fit_gpy, pred_gpy),
     "SMT": (fit_smt, pred_smt),
     "OpenTURNS": (fit_openturns, pred_openturns),
+    "GPyTorch": (fit_gpytorch, pred_gpytorch),
 }
 
 

--- a/bench/comparison/run_r.R
+++ b/bench/comparison/run_r.R
@@ -6,12 +6,14 @@
 # interpolation (no nugget), hyperparameters by MLE (package defaults).
 # Per-fit wall-clock budget via setTimeLimit (default 300 s).
 #
-# Usage: Rscript run_r.R [data_dir] [out_csv] [budget_seconds]
+# Usage: Rscript run_r.R [data_dir] [out_csv] [budget_seconds] [packages]
+#   packages: comma-separated subset of names(fitters), default = all
 
 args <- commandArgs(trailingOnly = TRUE)
 data_dir <- ifelse(length(args) >= 1, args[1], "data")
 out_csv  <- ifelse(length(args) >= 2, args[2], "results/r.csv")
 budget   <- ifelse(length(args) >= 3, as.numeric(args[3]), 300)
+pkg_arg  <- ifelse(length(args) >= 4, args[4], NA)
 
 dir.create(dirname(out_csv), recursive = TRUE, showWarnings = FALSE)
 
@@ -44,6 +46,8 @@ fitters <- list(
     })
 )
 
+pkgs <- if (is.na(pkg_arg)) names(fitters) else strsplit(pkg_arg, ",")[[1]]
+
 metrics <- function(y, mu, sd) {
   rmse <- sqrt(mean((y - mu)^2))
   q2 <- 1 - sum((y - mu)^2) / sum((y - mean(y))^2)
@@ -66,7 +70,7 @@ for (xtr in sort(Sys.glob(file.path(data_dir, "*", "n*", "rep*", "X_train.csv"))
   d <- ncol(X)
   colnames(X) <- colnames(Xt) <- paste0("x", seq_len(d))
 
-  for (pkg in names(fitters)) {
+  for (pkg in pkgs) {
     fit_time <- pred_time <- rmse <- q2 <- nlpd <- NA
     status <- "ok"
     res <- tryCatch({

--- a/bench/comparison/run_stk.m
+++ b/bench/comparison/run_stk.m
@@ -1,0 +1,89 @@
+## Benchmark STK (https://github.com/stk-kriging/stk) against the other
+## packages, on the shared datasets produced by make_datasets.py -- same
+## protocol as run_python.py / run_r.R: Matern 5/2 anisotropic (ARD)
+## covariance, constant trend, interpolation (no nugget beyond STK's own
+## numerical safeguards), hyperparameters by MLE with STK's default
+## data-driven initial guess (stk_param_estim with no param0, like
+## DiceKriging/RobustGaSP).
+##
+## Unlike run_python.py/run_r.R, no per-fit wall-clock budget is enforced
+## here: Octave has no clean equivalent of R's setTimeLimit or Python's
+## subprocess timeout for interrupting a running computation mid-fit.
+## Failures still surface as status=error; rely on the CI step's own
+## timeout-minutes as a backstop against a stuck fit.
+##
+## Usage: octave run_stk.m <stk_path> <data_dir> <out_csv>
+##
+## Output: <out_csv> with columns
+##   func,d,n,rep,package,fit_time,pred_time,rmse,q2,nlpd,status
+
+args = argv();
+stk_path = args{1};
+data_dir = args{2};
+out_csv = args{3};
+
+addpath(stk_path);
+stk_init;
+
+out_dir = fileparts(out_csv);
+if ~isempty(out_dir) && ~exist(out_dir, "dir")
+  mkdir(out_dir);
+endif
+
+function m = read_mat(p)
+  m = dlmread(p, ",");
+endfunction
+
+dirs = sort(glob(fullfile(data_dir, "*", "n*", "rep*", "X_train.csv")));
+rows = {"func,d,n,rep,package,fit_time,pred_time,rmse,q2,nlpd,status"};
+
+for i = 1:numel(dirs)
+  xtr = dirs{i};
+  rdir = fileparts(xtr);
+  ndir = fileparts(rdir);
+  fdir = fileparts(ndir);
+  [~, func] = fileparts(fdir);
+  [~, nname] = fileparts(ndir);
+  n = str2double(nname(2:end));
+  [~, repname] = fileparts(rdir);
+  rep = str2double(repname(4:end));
+
+  X = read_mat(xtr);
+  y = read_mat(fullfile(rdir, "y_train.csv"));
+  Xt = read_mat(fullfile(fdir, "X_test.csv"));
+  yt = read_mat(fullfile(fdir, "y_test.csv"));
+  d = columns(X);
+
+  status = "ok";
+  fit_time = NaN; pred_time = NaN; rmse = NaN; q2 = NaN; nlpd = NaN;
+  try
+    t0 = time();
+    model = stk_model(@stk_materncov52_aniso, d);
+    model = stk_param_estim(model, X, y);
+    fit_time = time() - t0;
+
+    t0 = time();
+    zp = stk_predict(model, X, y, Xt);
+    pred_time = time() - t0;
+
+    mu = zp.mean;
+    sd = sqrt(max(zp.var, 0));
+    rmse = sqrt(mean((yt - mu).^2));
+    q2 = 1 - sum((yt - mu).^2) / sum((yt - mean(yt)).^2);
+    s2 = max(sd, 1e-12).^2;
+    nlpd = mean(0.5 * log(2 * pi * s2) + 0.5 * (yt - mu).^2 ./ s2);
+  catch err
+    status = "error";
+    fprintf(stderr, "[STK %s n=%d rep=%d] %s\n", func, n, rep, err.message);
+  end_try_catch
+
+  rows{end + 1} = sprintf("%s,%d,%d,%d,STK,%s,%s,%s,%s,%s,%s", ...
+    func, d, n, rep, ...
+    num2str(fit_time), num2str(pred_time), ...
+    num2str(rmse), num2str(q2), num2str(nlpd), status);
+  disp(rows{end});
+endfor
+
+fid = fopen(out_csv, "w");
+fprintf(fid, "%s\n", strjoin(rows, "\n"));
+fclose(fid);


### PR DESCRIPTION
## Summary
The last comparison-benchmark CI run (scheduled, 2026-08-01) showed several
outlier RMSEs: GPy/OpenTURNS/sklearn essentially failing (RMSE ~45-90,
Q²≈0, i.e. predicting close to the training mean) on `borehole`, and
sklearn failing the same way on `hartmann3`/`hartmann6`. Verified the fit
*does* run in all cases (no crash, no swallowed exception, status=ok,
10/10 reps) — this isn't a harness bug where fitting is skipped, it's a
fit-quality issue:

- `borehole`'s 8 dimensions span 5+ orders of magnitude in raw physical
  units (`r` ∈ [100, 50000] vs `rw` ∈ [0.05, 0.15]). GPy/sklearn/OpenTURNS
  were left at `length_scale=1`/`theta0=1e-2` — at that scale the
  correlation matrix collapses to near-identity, so nothing is learned.
  `pylibkriging`/`DiceKriging`/`RobustGaSP` don't have this problem because
  they derive their search range from the actual data (internally, or via
  data-range-computed default optimizer bounds).
- `hartmann3`/`hartmann6` are already in `[0,1]^d`, but have short
  correlation lengths (sharp local bumps). sklearn's
  `n_restarts_optimizer=0` (its own real default) means a single MLE run
  from `length_scale=1`, which sits in a near-zero-gradient region for
  this kind of function — a well-known GP-fitting trap.

## Fix
`bench/comparison/run_python.py`: added `_length_scale_init(X)`, deriving
a data-range-aware `(init, lower, upper)` for the ARD length-scale, used
for GPy, scikit-learn and OpenTURNS. sklearn and GPy also get a handful of
optimizer restarts (`N_RESTARTS = 5`). SMT and the R packages weren't
touched — SMT already normalizes internally (its `borehole` results were
fine), and DiceKriging/RobustGaSP were unaffected.

This is a fit-quality fix, not a change of kernel/trend/objective — same
"fair default MLE fit" the benchmark targets, not a tuned/best-case setup.
`bench/comparison/README.md`'s fairness-caveats section documents this.

## CI
Temporarily added `fix/comparison-benchmark-scaling` to the `push:`
trigger in `bench-comparison.yml` so this gets exercised before merge —
remove that branch entry (and the still-unremoved
`feature/comparison-benchmark` one from the PR that introduced this
workflow) once verified. This is a ~5h job (bench-python), so it'll take a
while.

## Test plan
- [ ] CI run on this branch: `borehole` RMSE for GPy/sklearn/OpenTURNS
      should land in the same ballpark as pylibkriging/DiceKriging (not
      45-90), and `hartmann3`/`hartmann6` sklearn RMSE should drop from
      ~0.95/~0.37 (≈ std(y), i.e. no fit) to something comparable to the
      other packages.
- [ ] No new timeouts/errors introduced for GPy/sklearn/OpenTURNS on any
      case (`ok/total` should stay 10/10).