### PR TITLE
chore(julia): compat bounds + README for General registry

### DIFF
--- a/bindings/Julia/jlibkriging/Project.toml
+++ b/bindings/Julia/jlibkriging/Project.toml
@@ -8,5 +8,10 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[compat]
+julia = "1"
+Libdl = "1"
+Test = "1"
+
 [targets]
 test = ["Test"]

--- a/bindings/Julia/jlibkriging/README.md
+++ b/bindings/Julia/jlibkriging/README.md
@@ -1,0 +1,11 @@
+# jlibkriging
+
+Julia binding for [libKriging](https://github.com/libKriging/libKriging), a fast, portable Kriging library written in C++.
+
+This package is distributed as a subdirectory of the libKriging monorepo. See
+[`bindings/Julia/README.md`](../README.md) for prerequisites, build instructions
+(requires building libKriging with `-DENABLE_JULIA_BINDING=on`), and usage examples.
+
+## License
+
+Apache-2.0, see [`LICENSE`](../../../LICENSE) at the repository root.


### PR DESCRIPTION
## Summary
- Add `[compat]` section to `bindings/Julia/jlibkriging/Project.toml` (`julia`, `Libdl`, `Test`) — required by the General registry's AutoMerge bot, without which the registration PR would sit stuck in manual review.
- Add `bindings/Julia/jlibkriging/README.md` pointing to the existing `bindings/Julia/README.md` build/usage docs and the repo's Apache-2.0 license.

Context: the Julia Registrator GitHub App has just been installed on `libKriging/libKriging`, and `release-julia.yml` already triggers registration on tagged releases (`v*`). This PR clears the remaining AutoMerge blockers so the next release tag registers cleanly and automatically.

## Test plan
- [ ] CI: Julia binding build/test matrix (Linux/macOS/Windows) passes on this PR
- [ ] `Pkg.develop(path="bindings/Julia/jlibkriging")` + `Pkg.test("jlibkriging")` locally
- [ ] At the next tagged release, confirm the `@JuliaRegistrator register` comment triggers a General registry PR that AutoMerges without manual intervention