### PR TITLE
Design: Markov-type co-kriging (AR(1) multi-fidelity + collocated)

### DIFF
--- a/todo/ANALYSIS.md
+++ b/todo/ANALYSIS.md
@@ -113,7 +113,7 @@ dépôt : `nestedkriging_branin2d_{py,r,julia}.ipynb`).
 
 ## 6. Validation et documentation
 
-- `tests/MultiFidelityKrigingTest.cpp` + valeurs de référence dans
+- `tests/MarkovCoKrigingTest.cpp` + valeurs de référence dans
   `tests/references/`.
 - Oracle naturel : **`MuFiCokriging`**, le package R de Le Gratiet lui-même —
   cohérent avec la validation déjà faite contre DiceKriging

--- a/todo/ANALYSIS.md
+++ b/todo/ANALYSIS.md
@@ -1,0 +1,137 @@
+# Analyse : implémenter le multi-fidélité (co-krigeage récursif AR(1)) dans libKriging
+
+> Analyse produite le 2026-08-04. Reflète l'état du dépôt à cette date.
+
+Motivation : fonctionnalité manquante la plus demandée en simulation
+industrielle (coupler un code cher/fin avec un ou plusieurs codes
+grossiers/rapides), et cohérente avec l'ADN du projet — l'héritage
+DiceKriging, dont l'auteur du modèle récursif (L. Le Gratiet) fait partie de
+la même famille d'outils (`MuFiCokriging`).
+
+## 1. La théorie (Le Gratiet 2013) — bonne nouvelle
+
+Modèle auto-régressif de Kennedy & O'Hagan (2000), reformulé récursivement :
+
+    Z_t(x) = ρ_{t-1}(x) · Z_{t-1}(x) + δ_t(x),   t = 2..s
+    δ_t ⊥ Z_{t-1},   δ_t ~ GP(f_t(x)ᵀ β_t, σ_t² r_t(·,·;θ_t))
+
+avec `t=1` la fidélité la plus basse (la moins chère) et `t=s` la plus haute.
+
+Avec des **plans emboîtés** `D_s ⊆ D_{s-1} ⊆ … ⊆ D_1`, la vraisemblance
+jointe se factorise en `s` vraisemblances indépendantes. Conséquences :
+
+- **pas de matrice de covariance jointe à assembler ni à inverser** :
+  `s` fits `Kriging` indépendants sur les résidus `y_t − ρ·y_{t-1}(D_t)`,
+  en `O(Σ_t n_t³)` au lieu de `O((Σ_t n_t)³)` ;
+- `ρ` s'estime **comme un coefficient de tendance** si on ajoute
+  `y_{t-1}(D_t) · g(x)` en colonne(s) de la matrice de régression `F` du
+  niveau `t` → réutilise directement la machinerie GLS / `beta` profilé
+  existante de `KrigingImpl` ;
+- prédiction récursive :
+
+      μ_t(x)  = ρ_{t-1}(x) · μ_{t-1}(x) + μ_{δt}(x)
+      s²_t(x) = ρ_{t-1}(x)² · s²_{t-1}(x) + s²_{δt}(x)
+
+C'est donc une **classe de composition**, exactement le patron de
+`NestedKriging` (526 l. `.cpp` / 176 l. `.hpp`, vecteur de sous-`Kriging`,
+pas de save/load).
+
+## 2. Le vrai point dur côté core
+
+`Trend::RegressionModel` est un **enum fermé** `{None, Constant, Linear,
+Interactive, Quadratic}` (`src/lib/include/libKriging/Trend.hpp`) : il
+n'existe aucun chemin pour une matrice `F` fournie par l'appelant.
+`Trend::regressionModelMatrix(regmodel, newXt)` construit toujours `F` à
+partir de l'enum.
+
+Deux options :
+
+- **(a) chemin « F custom » dans `KrigingImpl`** → `ρ` estimé conjointement
+  avec `β` par GLS, formulation exacte de Le Gratiet, propre et sans
+  optimisation supplémentaire ; **mais** touche le cœur de `Kriging`, donc
+  risque de régression sur toutes les classes existantes.
+- **(b) profilage externe de `ρ`** : optimisation 1-D (ou `p`-D si
+  `ρ(x)=g(x)ᵀρ`) par niveau, autour d'un `Kriging` non modifié → **zéro
+  impact** sur le core, mais moins élégant, un peu plus lent, et l'incertitude
+  sur `ρ` reste hors du modèle.
+
+Recommandation : prototyper en **(b)** pour valider les formules contre
+`MuFiCokriging`, puis migrer vers **(a)** si le surcoût ou l'imprécision
+le justifie.
+
+## 3. Rupture d'API : `(y, X)` devient une liste de niveaux
+
+Toute la bibliothèque expose `fit(vec y, mat X, …)`. Le multi-fidélité
+impose `fit(vector<vec> y, vector<mat> X, …)` plus des options par niveau.
+
+**C'est ça qui coûte, pas les maths** : le marshalling de listes de matrices
+doit être refait dans les **5 bindings**, dont deux pénibles :
+
+- **Julia** : ABI C plate (`bindings/Julia/jlibkriging/csrc/libkriging_c.cpp`)
+  — tableaux de pointeurs + tableaux de dimensions à passer à la main ;
+- **Octave/MATLAB** : `*_binding.cpp/.hpp` + classe `.m` (cell arrays de
+  matrices, et rappel du piège maison : les entiers doivent être `int32(...)`).
+
+**Python** (pybind11 + carma) et **R** (`*_binding.cpp` + `*Class.R` +
+`RcppExports` + `.Rd` + `NAMESPACE`) sont plus mécaniques.
+
+Compter ~4 fichiers × 5 bindings + 1 notebook démo chacun (convention du
+dépôt : `nestedkriging_branin2d_{py,r,julia}.ipynb`).
+
+## 4. Surface fonctionnelle à décider (scope)
+
+| Fonction | Coût | Recommandation v1 |
+|---|---|---|
+| `fit` / `predict` | cœur | oui |
+| `logLikelihood` (somme des LL par niveau) | faible | oui |
+| `simulate` récursif | moyen | oui — simulation niveau par niveau, propagée |
+| `update` (ajout d'un point au niveau `t` → refit des niveaux ≥ `t`) | moyen | v1 si possible : c'est *le* cas d'usage industriel (enrichissement adaptatif / co-EGO) |
+| `save` / `load` | moyen | différable (`NestedKriging` l'a différé) |
+| variante bayésienne (priors sur `β`, `σ²`, `ρ` → variance prédictive corrigée) | élevé | v2 |
+| `WarpKriging` comme sous-modèle de niveau | faible si templatisé | option (paramètre), surtout pas une classe séparée |
+
+## 5. Pièges spécifiques à anticiper
+
+- **Plans emboîtés obligatoires** pour la formulation exacte → contrôle
+  runtime + message d'erreur explicite, ou mode approché assumé (utiliser
+  `μ_{t-1}(D_t)` prédit au lieu de `y_{t-1}(D_t)` observé, ce qui introduit
+  une variance non comptabilisée). **En pratique industrielle les plans ne
+  sont presque jamais emboîtés** — il faut trancher tôt, c'est structurant.
+- **`normalize`** doit être **global**, pas par niveau : une normalisation
+  indépendante par niveau casse la relation d'échelle portée par `ρ`.
+  (Rappel : `NestedKriging` ne supporte pas encore `normalize` du tout.)
+- **Bruit** : `Kriging` gère déjà `noise` (vecteur) et `"nugget"` via
+  `NoiseModel {None, Nugget, Heterogeneous}` → la basse-fidélité stochastique
+  (Monte-Carlo, CFD instationnaire, éléments discrets) marche « gratuitement ».
+  Gros argument de vente, à mettre en avant dans la doc.
+- **Sous-estimation de la variance prédictive** si `ρ` et les hyperparamètres
+  sont traités comme connus (plug-in). C'est exactement ce que la variante
+  bayésienne de Le Gratiet corrige.
+- **Composition avec les classes existantes** : ne pas créer
+  `MultiFidelityWarpKriging`, `MultiFidelityNestedKriging`, … — le type de
+  sous-modèle doit être une **option**, sinon explosion combinatoire.
+
+## 6. Validation et documentation
+
+- `tests/MultiFidelityKrigingTest.cpp` + valeurs de référence dans
+  `tests/references/`.
+- Oracle naturel : **`MuFiCokriging`**, le package R de Le Gratiet lui-même —
+  cohérent avec la validation déjà faite contre DiceKriging
+  (cf. `bindings/R/rlibkriging/DiceKriging.md` et `tests/references/`).
+- `skills/libkriging/SKILL.md` §1 : nouvelle branche dans l'arbre de décision
+  (« avez-vous plusieurs niveaux de fidélité ? ») + les 5
+  `skills/libkriging/references/*.md` + `CHANGELOG.md`.
+
+## 7. Estimation
+
+- Cœur C++ + tests unitaires : **~1–2 semaines**.
+- Bindings + notebooks + documentation : **~2–3 semaines** (le gros morceau).
+
+**Séquencement proposé**
+
+1. Trancher les décisions ouvertes (`DESIGN.md`) : traitement de `ρ`, support
+   des plans non-emboîtés, forme de la signature `fit`.
+2. Prototype C++ + test contre `MuFiCokriging`.
+3. Bindings dans l'ordre **Python → R → Julia → Octave/MATLAB**
+   (du plus simple au plus pénible ; Python sert de terrain d'essai à la
+   convention de marshalling des listes).

--- a/todo/DESIGN.md
+++ b/todo/DESIGN.md
@@ -1,0 +1,156 @@
+# Conception : `MultiFidelityKriging`
+
+## 1. Modèle
+
+`s` niveaux de fidélité, `t = 1` le moins cher / le moins fidèle,
+`t = s` le code de référence.
+
+    Z_1(x) ~ GP( f_1(x)ᵀ β_1 , σ_1² r_1(·,·;θ_1) )
+    Z_t(x) = ρ_{t-1}(x) · Z_{t-1}(x) + δ_t(x)          t = 2..s
+    δ_t    ~ GP( f_t(x)ᵀ β_t , σ_t² r_t(·,·;θ_t) ),   δ_t ⊥ Z_{t-1}
+
+Formes de `ρ` à supporter :
+
+| Forme | Paramètres | Usage |
+|---|---|---|
+| `"constant"` | 1 | défaut, cas le plus courant |
+| `"linear"` : `ρ(x) = ρ_0 + Σ_k ρ_k x_k` | `d+1` | biais dépendant de x |
+| plus généralement `ρ(x) = g(x)ᵀ ρ` | `dim(g)` | même arbre de bases que `Trend::RegressionModel` |
+
+## 2. Estimation — la factorisation
+
+**Hypothèse structurante : plans emboîtés** `D_s ⊆ D_{s-1} ⊆ … ⊆ D_1`.
+
+Sous cette hypothèse, la vraisemblance jointe de `(y_1, …, y_s)` se factorise :
+
+    L(y_1,…,y_s) = L_1(y_1) · Π_{t=2..s} L_t( y_t | y_{t-1}(D_t) )
+
+et chaque facteur `L_t` est **exactement** la vraisemblance d'un krigeage
+ordinaire sur `D_t` avec :
+
+- observations  `y_t`
+- matrice de régression  `F_t = [ diag(y_{t-1}(D_t)) · G(D_t) | F(D_t) ]`
+  où `G` est la base de `ρ` et `F` la base de tendance de `δ_t`
+- coefficients  `β̃_t = [ ρ , β_t ]`
+
+Donc `ρ` et `β_t` sortent ensemble du même GLS profilé, et `σ_t²` du même
+profilage que d'habitude. **Aucune optimisation supplémentaire** — c'est
+l'option (a).
+
+### Option (a) — matrice `F` fournie par l'appelant
+
+Nécessite d'ouvrir un chemin dans `KrigingImpl` acceptant un `F` explicite
+au lieu de le dériver de `Trend::RegressionModel`.
+
+- Avantages : formulation exacte, `ρ` gratuit, incertitude sur `ρ` incluse
+  dans la variance via le terme GLS habituel.
+- Coût : modification du cœur partagé par `Kriging`, `WarpKriging`,
+  `MLPKriging`, `NestedKriging` → risque de régression, à couvrir par les
+  tests existants.
+- Effet de bord positif : un `F` custom est aussi ce dont on aurait besoin
+  pour d'autres extensions (tendances utilisateur, bases physiques).
+
+### Option (b) — profilage externe de `ρ`
+
+Boucle externe sur `ρ` ; pour chaque `ρ` candidat, fit d'un `Kriging`
+standard sur `z_t = y_t − ρ(D_t) ⊙ y_{t-1}(D_t)` ; on retient le `ρ`
+maximisant la LL concentrée.
+
+- Avantages : **zéro modification du core**, prototypage immédiat.
+- Coût : une optimisation 1-D (ou `dim(g)`-D) par niveau imbriquée autour
+  d'une optimisation d'hyperparamètres ; incertitude sur `ρ` non propagée.
+
+> **Recommandation** : prototyper en (b), valider numériquement contre
+> `MuFiCokriging`, puis basculer en (a).
+
+## 3. Prédiction
+
+Récursion, du niveau 1 vers le niveau `s` :
+
+    μ_1(x)  = krigeage ordinaire du sous-modèle 1
+    s²_1(x) = idem
+
+    μ_t(x)  = ρ_{t-1}(x) · μ_{t-1}(x) + μ_{δt}(x)
+    s²_t(x) = ρ_{t-1}(x)² · s²_{t-1}(x) + s²_{δt}(x)
+
+En version plug-in (`ρ` connu). En version bayésienne (v2), un terme
+supplémentaire apparaît, fonction de la variance a posteriori de `ρ`.
+
+`predict` doit rendre `(mean, stdev)` a minima ; la signature de `Kriging`
+rend `(mean, stdev, cov, mean_deriv, stdev_deriv)` — décider si on aligne
+(les dérivées se propagent aussi par la récursion, mais c'est du travail
+supplémentaire).
+
+## 4. Simulation
+
+Récursivement : simuler `nsim` trajectoires de `Z_1` aux points demandés,
+puis pour chaque `t`, simuler `δ_t` et composer
+`Z_t = ρ_{t-1} ⊙ Z_{t-1} + δ_t`, **avec la même graine propagée**
+trajectoire par trajectoire. C'est la seule façon d'obtenir des
+trajectoires jointes cohérentes.
+
+## 5. Mise à jour (`update`)
+
+Ajout de `(x_new, y_new)` **au niveau `t`** :
+
+- niveaux `< t` : inchangés ;
+- niveau `t` : `update` du sous-modèle ;
+- niveaux `> t` : la relation d'emboîtement peut être rompue, et `y_{t}(D_{t+1})`
+  a changé si `x_new ∈ D_{t+1}` → refit des niveaux supérieurs.
+
+C'est le cas d'usage industriel n°1 (enrichissement adaptatif, co-EGO :
+« quel point, à quel niveau de fidélité ? »). À ne pas sacrifier.
+
+## 6. Décisions ouvertes (BLOQUANTES — à trancher avant tout code)
+
+### D1. Traitement de `ρ` : option (a) ou (b) ?
+Voir §2. Impact : modification ou non de `KrigingImpl`.
+**Proposition : (b) pour le prototype, (a) pour la version finale.**
+
+### D2. Plans non-emboîtés : refus, ou mode approché ?
+- *Refus strict* : contrôle runtime, message clair, doc explicite.
+  Simple, honnête, mais bloque une majorité de cas industriels réels.
+- *Mode approché* : remplacer `y_{t-1}(D_t)` par `μ_{t-1}(D_t)` prédit.
+  La factorisation n'est plus exacte et la variance est sous-estimée
+  (l'incertitude de prédiction du niveau inférieur n'est pas propagée).
+- *Co-krigeage complet* (covariance jointe, sans factorisation) : exact
+  pour tout plan, mais `O((Σ n_t)³)` et beaucoup plus de code.
+
+**Proposition : v1 = plans emboîtés exigés + contrôle explicite ;
+mode approché derrière une option nommée sans ambiguïté
+(`allow_non_nested=true`) documentée comme approximation.**
+
+### D3. Forme de la signature `fit`
+- `fit(std::vector<arma::vec> y, std::vector<arma::mat> X, …)` — explicite,
+  mais nouvelle convention de marshalling à inventer dans 5 bindings.
+- Alternative : `fit(arma::vec y, arma::mat X, arma::uvec level)` — un seul
+  jeu de données plus un vecteur d'index de niveau. **Aucune** nouvelle
+  convention de marshalling (tout est déjà supporté partout), au prix d'une
+  API un peu moins naturelle et d'un découpage interne.
+
+**Proposition : sérieusement envisager la variante `level`** — elle divise
+probablement par deux le coût côté bindings, qui est le poste dominant.
+À arbitrer avec les utilisateurs cibles.
+
+### D4. Options par niveau
+`kernel`, `regmodel`, `optim`, `objective`, `noise` : scalaire diffusé à
+tous les niveaux, ou vecteur de taille `s` ? (Un vecteur est plus riche —
+typiquement un nugget seulement sur la basse-fidélité stochastique — mais
+alourdit encore le marshalling.)
+**Proposition : accepter les deux — taille 1 = diffusion.**
+
+### D5. Nom de la classe
+`MultiFidelityKriging` ? `CoKriging` ? `MuFiKriging` ?
+Le nom se propage dans 5 bindings + doc ; le changer après coup est coûteux.
+`MultiFidelityKriging` est explicite et cohérent avec `NestedKriging` /
+`WarpKriging` / `MLPKriging`.
+
+## 7. Invariants et contraintes à faire respecter
+
+- `X_t` est toujours `n_t × d`, `d` **identique** à tous les niveaux ;
+  `y_t` est un vecteur de longueur `n_t` (convention du dépôt, cf. `AGENTS.md`).
+- `normalize` : global uniquement, jamais par niveau (§5 de `ANALYSIS.md`).
+- Ordre des niveaux : `t=1` = plus basse fidélité. **Documenter clairement**,
+  c'est une source d'erreur classique (certains outils numérotent à l'envers).
+- `s ≥ 2` ; `s = 1` doit soit être refusé, soit dégénérer proprement en
+  `Kriging`.

--- a/todo/DESIGN.md
+++ b/todo/DESIGN.md
@@ -157,17 +157,28 @@ Justification du changement de position :
 mode approché derrière une option nommée sans ambiguïté
 (`allow_non_nested=true`) documentée comme approximation.**
 
-### D3. Forme de la signature `fit`
-- `fit(std::vector<arma::vec> y, std::vector<arma::mat> X, …)` — explicite,
-  mais nouvelle convention de marshalling à inventer dans 5 bindings.
-- Alternative : `fit(arma::vec y, arma::mat X, arma::uvec level)` — un seul
-  jeu de données plus un vecteur d'index de niveau. **Aucune** nouvelle
-  convention de marshalling (tout est déjà supporté partout), au prix d'une
-  API un peu moins naturelle et d'un découpage interne.
+### D3. Forme de la signature `fit` : TRANCHÉE — variante B (`level`)
+`fit(arma::vec y, arma::mat X, arma::uvec level, …)` — un seul jeu de
+données plus un vecteur d'index de niveau (`level[i] ∈ [0, s-1]`,
+`0` = niveau parent / racine de la chaîne). **Aucune** nouvelle convention
+de marshalling : réutilise exactement le `(y, X)` déjà supporté dans les
+5 bindings, contre une nouvelle convention de listes de matrices à inventer
+partout pour la variante A — c'était le poste dominant du projet (cf.
+`TOUCHPOINTS.md` §8), donc l'argument décisif.
 
-**Proposition : sérieusement envisager la variante `level`** — elle divise
-probablement par deux le coût côté bindings, qui est le poste dominant.
-À arbitrer avec les utilisateurs cibles.
+`level` reste un `arma::uvec` (index catégoriel ordonné, pas une valeur de
+coût/fidélité continue) — cf. discussion : un type continu ne ferait que
+déplacer le problème de binning sans bénéfice, chaque niveau ayant de toute
+façon besoin de son propre sous-`Kriging` et de son propre `ρ`. L'hypothèse
+implicite `parent(t) = t-1` (chaîne linéaire, pas de topologie en arbre)
+reste posée pour v1 ; une généralisation (`arma::ivec parent` explicite)
+serait nécessaire pour des topologies non linéaires mais n'a pas d'oracle
+de référence connu (Le Gratiet et MM1/MM2 ne couvrent que la chaîne) —
+hors scope tant qu'aucune demande utilisateur ne le justifie.
+
+**Conséquence sur l'esquisse d'API** (`todo/draft/MarkovCoKriging.hpp`) :
+la variante A (`vector<vec>`/`vector<mat>`) est retirée, seule la
+signature `(y, X, level)` est conservée.
 
 ### D4. Options par niveau
 `kernel`, `regmodel`, `optim`, `objective`, `noise` : scalaire diffusé à

--- a/todo/DESIGN.md
+++ b/todo/DESIGN.md
@@ -1,9 +1,30 @@
-# Conception : `MultiFidelityKriging`
+# Conception : `MarkovCoKriging`
+
+## 0. Généralisation retenue : AR(1) et co-krigeage collocalisé, même code
+
+Le modèle ci-dessous n'est pas spécifique à la « fidélité » : c'est un cas
+de **co-krigeage de type Markov** (Journel 1999, MM1/MM2 — cf.
+`REFERENCES.md`), dont l'hypothèse structurante est que la covariance
+croisée entre deux champs est **proportionnelle** à une covariance directe.
+L'AR(1) de Le Gratiet en est l'instance hiérarchique (`t` = niveau de
+fidélité, plans emboîtés par coût croissant). Le **co-krigeage collocalisé**
+(Xu et al. 1992) en est l'instance à `s=2` **sans notion d'ordre de
+fidélité** : `f_1` = variable secondaire connue sur un plan large, `f_2` =
+variable primaire sous-échantillonnée, avec la même contrainte structurale
+`D_2 ⊆ D_1` (renommée, pas de coût/fidélité impliqué).
+
+**Conséquence pour l'implémentation : les deux cas partagent exactement le
+même code.** Seule la sémantique du mot « niveau » change (position dans
+une chaîne de dépendance de covariance, pas nécessairement un ordre de
+coût). Voir §7bis pour le détail de l'implémentation « expositions
+uniquement » qui découle de ce constat.
 
 ## 1. Modèle
 
-`s` niveaux de fidélité, `t = 1` le moins cher / le moins fidèle,
-`t = s` le code de référence.
+`s` champs reliés en chaîne par une hypothèse de covariance croisée
+proportionnelle. Dans le cas AR(1), `t = 1` est le moins cher / le moins
+fidèle, `t = s` le code de référence ; dans le cas collocalisé, `s = 2` et
+`t = 1` est simplement la variable secondaire.
 
     Z_1(x) ~ GP( f_1(x)ᵀ β_1 , σ_1² r_1(·,·;θ_1) )
     Z_t(x) = ρ_{t-1}(x) · Z_{t-1}(x) + δ_t(x)          t = 2..s
@@ -103,9 +124,25 @@ C'est le cas d'usage industriel n°1 (enrichissement adaptatif, co-EGO :
 
 ## 6. Décisions ouvertes (BLOQUANTES — à trancher avant tout code)
 
-### D1. Traitement de `ρ` : option (a) ou (b) ?
-Voir §2. Impact : modification ou non de `KrigingImpl`.
-**Proposition : (b) pour le prototype, (a) pour la version finale.**
+### D1. Traitement de `ρ` : TRANCHÉE — option (b), **définitivement**
+Voir §2 et §7bis. Ce n'est plus « prototype (b) puis migration vers (a) » :
+**(b) est retenue en permanence**, pas seulement comme étape transitoire.
+
+Justification du changement de position :
+- (a) n'apporte de gain que sur la propagation de l'incertitude de `ρ`
+  dans la variance prédictive — un raffinement, pas une correction d'erreur.
+- (a) coûte une modification du chemin `F` partagé par `Kriging`,
+  `WarpKriging`, `MLPKriging`, `NestedKriging` → risque de régression sur
+  tout le core pour un gain marginal.
+- (b) permet de traiter l'AR(1) **et** le co-krigeage collocalisé avec le
+  même code, sans toucher à `KrigingImpl`/`Trend` (§0, §7bis) — l'argument
+  décisif.
+- La perte (incertitude sur `ρ` non propagée, estimation *plug-in*) est
+  documentée comme limitation permanente assumée, au même titre que la
+  variante bayésienne de Le Gratiet reste v2/hors-scope.
+
+**Conséquence sur `TOUCHPOINTS.md`** : les lignes « seulement si option (a) »
+(`Trend.hpp/.cpp`, `KrigingImpl.cpp/.hpp`) sont retirées du scope.
 
 ### D2. Plans non-emboîtés : refus, ou mode approché ?
 - *Refus strict* : contrôle runtime, message clair, doc explicite.
@@ -140,10 +177,75 @@ alourdit encore le marshalling.)
 **Proposition : accepter les deux — taille 1 = diffusion.**
 
 ### D5. Nom de la classe
-`MultiFidelityKriging` ? `CoKriging` ? `MuFiKriging` ?
+`MarkovCoKriging` ? `CoKriging` ? `MuFiKriging` ?
 Le nom se propage dans 5 bindings + doc ; le changer après coup est coûteux.
-`MultiFidelityKriging` est explicite et cohérent avec `NestedKriging` /
+`MarkovCoKriging` est explicite et cohérent avec `NestedKriging` /
 `WarpKriging` / `MLPKriging`.
+
+⚠ Mise à jour suite à §0 : la classe couvre aussi le co-krigeage
+collocalisé (`s=2`, pas de notion de coût/fidélité). Deux options :
+- garder `MarkovCoKriging` et documenter le cas `s=2` collocalisé
+  comme un usage particulier (paramètre `level` réinterprété comme
+  « position dans la chaîne », pas « coût ») — **zéro coût de renommage,
+  proposition retenue par défaut** ;
+- ou introduire un alias plus neutre (`CoKriging`) si le collocalisé
+  s'avère un cas d'usage aussi fréquent que l'AR(1) — à trancher seulement
+  si la demande utilisateur le justifie, pas maintenant.
+
+## 7bis. Plan d'implémentation « expositions uniquement » (option b verrouillée)
+
+Découle directement de D1 (§6) : **aucune modification de
+`KrigingImpl`/`Trend`/`Covariance`/`Optim`**. Toute la logique nouvelle vit
+dans un unique fichier de composition, sur le patron de `NestedKriging`.
+
+### Structure interne
+
+    class MarkovCoKrigingImpl {
+      std::vector<std::unique_ptr<Kriging>> m_subKrigings;  // 1 par niveau
+      std::vector<arma::vec>                m_rho;          // figé après fit
+      …
+    };
+
+- **Niveau 1** : `Kriging` standard, inchangé, sur `(X_1, y_1)`.
+- **Niveau `t ≥ 2`** : pour un `ρ_t` candidat (scalaire ou `g(x)ᵀρ_t`, cf.
+  D4), calcule le résidu `z_t = y_t − ρ_t(D_t) ⊙ ŷ_{t-1}(D_t)`, fit un
+  `Kriging` standard sur `(X_t, z_t)` (appel public inchangé), lit sa LL
+  concentrée. `ŷ_{t-1}(D_t)` = valeur observée si plan exactement emboîté,
+  ou `m_subKrigings[t-1]->predict(D_t)` sinon (mode approché de D2 — déjà
+  gratuit, aucun code nouveau requis pour ce cas).
+
+### Optimisation externe de `ρ`
+
+Boucle 1-D (ou `dim(g)`-D) autour du fit ci-dessus, qui maximise la LL
+concentrée en `ρ_t`. **Ne pas passer par `Optim.hpp`** : ce module est
+spécifique aux bornes/heuristiques de `θ` de `Kriging` et n'expose pas de
+minimiseur générique réutilisable (vérifié sur l'API actuelle). À la place,
+appeler directement `lbfgsb_cpp` (`dependencies/lbfgsb_cpp/`), **déjà
+vendorisé et déjà lié au build** — aucune nouvelle dépendance, aucun
+fichier core touché, juste un appel de plus depuis
+`MarkovCoKriging.cpp`.
+
+### `predict` / `simulate` / `logLikelihood`
+
+Inchangés par rapport à §3-4 : récursion pure sur `m_subKrigings`, aucun
+nouveau besoin côté core.
+
+### Ce qui sort du scope grâce à ce verrouillage
+
+- `Trend.hpp/.cpp` (chemin `F` custom) — supprimé de `TOUCHPOINTS.md`.
+- `KrigingImpl.cpp/.hpp` (accepter un `F` fourni) — supprimé.
+- Phase 2 de `PLAN.md` (« prototype hors arbre ») devient un prototype
+  **définitif**, pas une étape à refaire différemment en Phase 3 : il n'y a
+  plus de bascule d'option à opérer, seulement une intégration mécanique.
+
+### Le collocalisé « gratuit »
+
+Le co-krigeage collocalisé (Xu et al. 1992) est le cas `s=2` de cette même
+classe, sans autre développement : seule la documentation utilisateur
+change (pas de vocabulaire « fidélité »/« coût », juste « variable
+secondaire », cf. D5). Premier test de validation naturel : comparer contre
+une implémentation `gstat`/gslib du MM1, en plus de l'oracle
+`MuFiCokriging` déjà prévu pour l'AR(1) (cf. `PLAN.md` Phase 1).
 
 ## 7. Invariants et contraintes à faire respecter
 

--- a/todo/PLAN.md
+++ b/todo/PLAN.md
@@ -15,9 +15,11 @@ phase `n+1` avant de l'avoir atteint.
       ou co-krigeage complet. *(proposition : refus strict en v1 ; le mode
       approché reste gratuit à activer ensuite, cf. §7bis — il réutilise
       `predict` du niveau parent, déjà nécessaire de toute façon)*
-- [ ] **D3** : signature `fit` → `vector<vec>/vector<mat>` ou
-      `(y, X, level)`. **Décision la plus rentable** : elle conditionne le
-      coût des 5 bindings, poste dominant du projet.
+- [x] **D3** : signature `fit` → **TRANCHÉE : `(y, X, level)`** (`level:
+      arma::uvec`, index catégoriel de position dans la chaîne, pas une
+      valeur de coût continue). Réutilise le marshalling `(y, X)` déjà
+      existant dans les 5 bindings — pas de nouvelle convention à inventer.
+      Voir `DESIGN.md` D3.
 - [ ] **D4** : options par niveau (scalaire diffusé vs. vecteur).
 - [ ] **D5** : nom de la classe. *(proposition : garder `MarkovCoKriging`,
       documenter le cas `s=2` collocalisé comme usage particulier — voir
@@ -25,7 +27,7 @@ phase `n+1` avant de l'avoir atteint.
 - [ ] Scope v1 : `update` dedans ou dehors ? `save`/`load` dedans ou dehors ?
 
 **Sortie** : `DESIGN.md` §6 mis à jour, chaque décision marquée TRANCHÉE
-avec sa justification. *(D1 fait ; D2/D3/D4/D5 restent à statuer.)*
+avec sa justification. *(D1, D3 faits ; D2/D4/D5 restent à statuer.)*
 
 ---
 

--- a/todo/PLAN.md
+++ b/todo/PLAN.md
@@ -7,65 +7,83 @@ phase `n+1` avant de l'avoir atteint.
 
 ## Phase 0 — Arbitrages (aucun code)
 
-- [ ] **D1** : traitement de `ρ` → option (a) `F` custom dans `KrigingImpl`,
-      ou (b) profilage externe. *(proposition : (b) puis (a))*
+- [x] **D1** : traitement de `ρ` → **TRANCHÉE : option (b) profilage
+      externe, définitivement** (pas de bascule vers (a) prévue). Permet de
+      couvrir AR(1) et co-krigeage collocalisé avec le même code, sans
+      toucher `KrigingImpl`/`Trend`. Voir `DESIGN.md` §6 D1, §7bis.
 - [ ] **D2** : plans non-emboîtés → refus strict, mode approché optionnel,
-      ou co-krigeage complet. *(proposition : refus strict en v1)*
+      ou co-krigeage complet. *(proposition : refus strict en v1 ; le mode
+      approché reste gratuit à activer ensuite, cf. §7bis — il réutilise
+      `predict` du niveau parent, déjà nécessaire de toute façon)*
 - [ ] **D3** : signature `fit` → `vector<vec>/vector<mat>` ou
       `(y, X, level)`. **Décision la plus rentable** : elle conditionne le
       coût des 5 bindings, poste dominant du projet.
 - [ ] **D4** : options par niveau (scalaire diffusé vs. vecteur).
-- [ ] **D5** : nom de la classe. *(proposition : `MultiFidelityKriging`)*
+- [ ] **D5** : nom de la classe. *(proposition : garder `MarkovCoKriging`,
+      documenter le cas `s=2` collocalisé comme usage particulier — voir
+      `DESIGN.md` D5)*
 - [ ] Scope v1 : `update` dedans ou dehors ? `save`/`load` dedans ou dehors ?
 
 **Sortie** : `DESIGN.md` §6 mis à jour, chaque décision marquée TRANCHÉE
-avec sa justification.
+avec sa justification. *(D1 fait ; D2/D3/D4/D5 restent à statuer.)*
 
 ---
 
-## Phase 1 — Oracle de validation (avant tout code C++)
+## Phase 1 — Oracles de validation (avant tout code C++)
 
-- [ ] Installer `MuFiCokriging` (R) — cf. `REFERENCES.md`.
+- [ ] Installer `MuFiCokriging` (R) — cf. `REFERENCES.md`. Oracle AR(1).
 - [ ] Produire un cas test reproductible : fonction analytique
       2-fidélités 1-D de Forrester et al. (2007), puis un cas 2-D.
 - [ ] Figer les sorties de référence (`theta`, `sigma2`, `rho`, `beta`, LL,
       moyennes et écarts-types de prédiction sur une grille) dans
       `tests/references/`.
+- [ ] Cas test collocalisé (`s=2`, pas de fidélité) : oracle MM1/MM2 via
+      `gstat` (R) ou gslib, cf. `REFERENCES.md` §Généralisation. Même
+      format de références figées.
 
-**Sortie** : jeu de références figé, indépendant de toute implémentation
-libKriging. *Rationale : sans oracle, impossible de distinguer un bug
-d'un désaccord de convention.*
+**Sortie** : jeux de références figés (AR(1) + collocalisé), indépendants
+de toute implémentation libKriging. *Rationale : sans oracle, impossible de
+distinguer un bug d'un désaccord de convention.*
 
 ---
 
-## Phase 2 — Prototype C++ hors arbre
+## Phase 2 — Prototype C++ (définitif, plus « hors arbre » à refaire)
 
-- [ ] Implémenter le fit récursif en option (b) dans un fichier isolé
-      (peut rester dans `wip2/draft/`).
-- [ ] Vérifier la reproduction des références de la phase 1 à la tolérance
-      des tests existants du dépôt.
+Depuis le verrouillage de D1 sur l'option (b) (`DESIGN.md` §7bis), ce
+prototype n'est plus une étape jetable : c'est directement le code visé
+pour la Phase 3, juste pas encore rattaché au build.
+
+- [ ] Implémenter le fit récursif — profilage externe de `ρ` via
+      `lbfgsb_cpp` (déjà vendorisé/lié, cf. `DESIGN.md` §7bis) — dans un
+      fichier isolé (`todo/draft/`).
+- [ ] Vérifier la reproduction des références AR(1) de la Phase 1 à la
+      tolérance des tests existants du dépôt.
+- [ ] Vérifier la reproduction des références collocalisées de la Phase 1.
 - [ ] Vérifier le cas dégénéré `s = 1` ≡ `Kriging`.
-- [ ] Vérifier le cas `ρ = 0` ≡ `Kriging` sur la seule haute-fidélité.
+- [ ] Vérifier le cas `ρ = 0` ≡ `Kriging` sur la seule haute-fidélité /
+      primaire.
 
-**Sortie** : formules validées numériquement. *C'est le seul jalon qui peut
-invalider la conception ; tout ce qui suit est de l'intégration.*
+**Sortie** : formules validées numériquement pour les deux cas d'usage
+(AR(1) et collocalisé). *C'est le seul jalon qui peut invalider la
+conception ; tout ce qui suit est de l'intégration mécanique.*
 
 ---
 
-## Phase 3 — Intégration au cœur
+## Phase 3 — Intégration au cœur (allégée : aucune touche à `KrigingImpl`/`Trend`)
 
-- [ ] `src/lib/include/libKriging/MultiFidelityKriging.hpp` (depuis `draft/`).
-- [ ] `src/lib/MultiFidelityKriging.cpp`.
-- [ ] Enregistrement dans `src/lib/CMakeLists.txt`.
-- [ ] `tests/MultiFidelityKrigingTest.cpp` + bloc dans `tests/CMakeLists.txt`.
+- [ ] `src/lib/include/libKriging/MarkovCoKriging.hpp` (depuis `draft/`).
+- [ ] `src/lib/MarkovCoKriging.cpp`.
+- [ ] Enregistrement dans `src/lib/CMakeLists.txt` (lien vers `lbfgsb_cpp`,
+      déjà une dépendance du projet — pas de nouvelle entrée `find_package`).
+- [ ] `tests/MarkovCoKrigingTest.cpp` + bloc dans `tests/CMakeLists.txt`
+      (cas AR(1) et collocalisé).
 - [ ] `predict`, `logLikelihood`, `summary`.
 - [ ] `simulate` récursif (graine propagée trajectoire par trajectoire).
 - [ ] `update` (si dans le scope v1).
-- [ ] Si option (a) retenue : chemin `F` custom dans `KrigingImpl` — **faire
-      passer la totalité de la suite de tests existante** avant et après,
-      c'est du code partagé par toutes les classes.
 
-**Sortie** : `ctest` vert, y compris toute la suite préexistante.
+**Sortie** : `ctest` vert, y compris toute la suite préexistante — *aucune
+régression possible sur `Kriging`/`WarpKriging`/`MLPKriging`/`NestedKriging`
+puisqu'aucun de leurs fichiers n'est modifié.*
 
 ---
 

--- a/todo/PLAN.md
+++ b/todo/PLAN.md
@@ -1,0 +1,104 @@
+# Plan d'implémentation
+
+Chaque phase a un **critère de sortie** vérifiable. Ne pas démarrer la
+phase `n+1` avant de l'avoir atteint.
+
+---
+
+## Phase 0 — Arbitrages (aucun code)
+
+- [ ] **D1** : traitement de `ρ` → option (a) `F` custom dans `KrigingImpl`,
+      ou (b) profilage externe. *(proposition : (b) puis (a))*
+- [ ] **D2** : plans non-emboîtés → refus strict, mode approché optionnel,
+      ou co-krigeage complet. *(proposition : refus strict en v1)*
+- [ ] **D3** : signature `fit` → `vector<vec>/vector<mat>` ou
+      `(y, X, level)`. **Décision la plus rentable** : elle conditionne le
+      coût des 5 bindings, poste dominant du projet.
+- [ ] **D4** : options par niveau (scalaire diffusé vs. vecteur).
+- [ ] **D5** : nom de la classe. *(proposition : `MultiFidelityKriging`)*
+- [ ] Scope v1 : `update` dedans ou dehors ? `save`/`load` dedans ou dehors ?
+
+**Sortie** : `DESIGN.md` §6 mis à jour, chaque décision marquée TRANCHÉE
+avec sa justification.
+
+---
+
+## Phase 1 — Oracle de validation (avant tout code C++)
+
+- [ ] Installer `MuFiCokriging` (R) — cf. `REFERENCES.md`.
+- [ ] Produire un cas test reproductible : fonction analytique
+      2-fidélités 1-D de Forrester et al. (2007), puis un cas 2-D.
+- [ ] Figer les sorties de référence (`theta`, `sigma2`, `rho`, `beta`, LL,
+      moyennes et écarts-types de prédiction sur une grille) dans
+      `tests/references/`.
+
+**Sortie** : jeu de références figé, indépendant de toute implémentation
+libKriging. *Rationale : sans oracle, impossible de distinguer un bug
+d'un désaccord de convention.*
+
+---
+
+## Phase 2 — Prototype C++ hors arbre
+
+- [ ] Implémenter le fit récursif en option (b) dans un fichier isolé
+      (peut rester dans `wip2/draft/`).
+- [ ] Vérifier la reproduction des références de la phase 1 à la tolérance
+      des tests existants du dépôt.
+- [ ] Vérifier le cas dégénéré `s = 1` ≡ `Kriging`.
+- [ ] Vérifier le cas `ρ = 0` ≡ `Kriging` sur la seule haute-fidélité.
+
+**Sortie** : formules validées numériquement. *C'est le seul jalon qui peut
+invalider la conception ; tout ce qui suit est de l'intégration.*
+
+---
+
+## Phase 3 — Intégration au cœur
+
+- [ ] `src/lib/include/libKriging/MultiFidelityKriging.hpp` (depuis `draft/`).
+- [ ] `src/lib/MultiFidelityKriging.cpp`.
+- [ ] Enregistrement dans `src/lib/CMakeLists.txt`.
+- [ ] `tests/MultiFidelityKrigingTest.cpp` + bloc dans `tests/CMakeLists.txt`.
+- [ ] `predict`, `logLikelihood`, `summary`.
+- [ ] `simulate` récursif (graine propagée trajectoire par trajectoire).
+- [ ] `update` (si dans le scope v1).
+- [ ] Si option (a) retenue : chemin `F` custom dans `KrigingImpl` — **faire
+      passer la totalité de la suite de tests existante** avant et après,
+      c'est du code partagé par toutes les classes.
+
+**Sortie** : `ctest` vert, y compris toute la suite préexistante.
+
+---
+
+## Phase 4 — Bindings, dans cet ordre
+
+Python sert de terrain d'essai à la convention de marshalling ; ne pas
+commencer par Julia ou Octave.
+
+- [ ] **Python** (pybind11/carma) + test + notebook `…_branin2d_py.ipynb`.
+- [ ] **R** (Rcpp) + `.Rd` + `NAMESPACE` + test + notebook.
+- [ ] **Julia** (ABI C plate) + test + notebook.
+- [ ] **Octave/MATLAB** (mex) + test.
+- [ ] Test de cohérence inter-bindings : mêmes entrées → mêmes sorties
+      (cf. `bindings/Python/pylibkriging/tests/binding_consistency_test.py`).
+
+**Sortie** : chaque binding reproduit les références de la phase 1.
+
+---
+
+## Phase 5 — Documentation
+
+- [ ] `skills/libkriging/SKILL.md` : branche multi-fidélité dans l'arbre §1.
+- [ ] Les 5 `skills/libkriging/references/*.md`.
+- [ ] `CHANGELOG.md`, `AGENTS.md`.
+- [ ] Documenter explicitement les pièges : ordre des niveaux (`t=1` = plus
+      basse fidélité), exigence d'emboîtement, `normalize` global.
+
+---
+
+## Rappels de politique du dépôt
+
+- **Ne jamais faire `git push`** (cf. `AGENTS.md`) — demander à l'utilisateur.
+- Sous-modules obligatoires : `git submodule update --init --recursive`.
+- `ENABLE_OCTAVE_BINDING` et `ENABLE_MATLAB_BINDING` sont **mutuellement
+  exclusifs**.
+- `ARMA_32BIT_WORD` doit rester cohérent entre le cœur et le binding R.

--- a/todo/README.md
+++ b/todo/README.md
@@ -1,0 +1,34 @@
+# wip2 — Multi-fidélité : co-krigeage récursif AR(1) (Le Gratiet)
+
+Dossier de travail pour l'implémentation d'un modèle multi-fidélité dans
+libKriging (`MultiFidelityKriging`).
+
+**État : analyse / conception. Aucun code produit dans l'arbre source.**
+Rien n'a encore été modifié dans `src/`, `bindings/`, `tests/` ou `skills/`.
+
+## Contenu
+
+| Fichier | Rôle |
+|---|---|
+| `ANALYSIS.md` | Analyse initiale : ce que l'implémentation implique, effort, séquencement |
+| `DESIGN.md` | Formulation mathématique détaillée + décisions de conception à trancher |
+| `TOUCHPOINTS.md` | Liste exhaustive des fichiers à créer / modifier (core, 5 bindings, tests, doc) |
+| `PLAN.md` | Checklist séquencée, phase par phase, avec critères de sortie |
+| `REFERENCES.md` | Bibliographie et oracles de validation |
+| `draft/MultiFidelityKriging.hpp` | Esquisse d'API C++ — vérifiée syntaxiquement, non branchée au build |
+
+## Reprise rapide
+
+1. Lire `DESIGN.md` §« Décisions ouvertes » — 3 arbitrages bloquent tout le reste
+   (traitement de `ρ`, plans non-emboîtés, forme de la signature `fit`).
+2. Puis suivre `PLAN.md` phase 0 → 5.
+
+## Contexte projet au moment de l'analyse
+
+- Aucune trace de multi-fidélité / co-krigeage dans le dépôt
+  (`grep -ri "fidelity\|cokriging"` → vide hors dépendances).
+- Le patron de référence à copier est `NestedKriging` : classe de composition
+  sur un `std::vector<std::unique_ptr<Kriging>>`, 526 l. `.cpp` / 176 l. `.hpp`,
+  save/load volontairement différé.
+- `wip/` (dossier voisin) contient une série de patches GEK (krigeage avec
+  gradients) — non lié, mais même convention de dossier de travail.

--- a/todo/README.md
+++ b/todo/README.md
@@ -1,7 +1,8 @@
-# wip2 — Multi-fidélité : co-krigeage récursif AR(1) (Le Gratiet)
+# todo — Co-krigeage de type Markov : AR(1) multi-fidélité (Le Gratiet) + collocalisé
 
-Dossier de travail pour l'implémentation d'un modèle multi-fidélité dans
-libKriging (`MultiFidelityKriging`).
+Dossier de travail pour l'implémentation d'un modèle de co-krigeage de type
+Markov dans libKriging (`MarkovCoKriging`), couvrant à la fois le
+multi-fidélité récursif AR(1) et le co-krigeage collocalisé.
 
 **État : analyse / conception. Aucun code produit dans l'arbre source.**
 Rien n'a encore été modifié dans `src/`, `bindings/`, `tests/` ou `skills/`.
@@ -15,13 +16,18 @@ Rien n'a encore été modifié dans `src/`, `bindings/`, `tests/` ou `skills/`.
 | `TOUCHPOINTS.md` | Liste exhaustive des fichiers à créer / modifier (core, 5 bindings, tests, doc) |
 | `PLAN.md` | Checklist séquencée, phase par phase, avec critères de sortie |
 | `REFERENCES.md` | Bibliographie et oracles de validation |
-| `draft/MultiFidelityKriging.hpp` | Esquisse d'API C++ — vérifiée syntaxiquement, non branchée au build |
+| `draft/MarkovCoKriging.hpp` | Esquisse d'API C++ — vérifiée syntaxiquement, non branchée au build |
 
 ## Reprise rapide
 
-1. Lire `DESIGN.md` §« Décisions ouvertes » — 3 arbitrages bloquent tout le reste
-   (traitement de `ρ`, plans non-emboîtés, forme de la signature `fit`).
-2. Puis suivre `PLAN.md` phase 0 → 5.
+1. **D1 (traitement de `ρ`) est tranchée : option (b) profilage externe,
+   définitivement** — zéro modification de `KrigingImpl`/`Trend`, et le
+   même code couvre l'AR(1) **et** le co-krigeage collocalisé (Journel
+   MM1/MM2, Xu et al. 1992). Voir `DESIGN.md` §0 et §7bis.
+2. Lire `DESIGN.md` §« Décisions ouvertes » restantes (D2 plans
+   non-emboîtés, D3 signature `fit`, D4 options par niveau, D5 nom).
+3. Puis suivre `PLAN.md` phase 0 → 5 (Phase 1 inclut désormais un oracle
+   collocalisé en plus de `MuFiCokriging`).
 
 ## Contexte projet au moment de l'analyse
 
@@ -30,5 +36,3 @@ Rien n'a encore été modifié dans `src/`, `bindings/`, `tests/` ou `skills/`.
 - Le patron de référence à copier est `NestedKriging` : classe de composition
   sur un `std::vector<std::unique_ptr<Kriging>>`, 526 l. `.cpp` / 176 l. `.hpp`,
   save/load volontairement différé.
-- `wip/` (dossier voisin) contient une série de patches GEK (krigeage avec
-  gradients) — non lié, mais même convention de dossier de travail.

--- a/todo/README.md
+++ b/todo/README.md
@@ -24,9 +24,12 @@ Rien n'a encore été modifié dans `src/`, `bindings/`, `tests/` ou `skills/`.
    définitivement** — zéro modification de `KrigingImpl`/`Trend`, et le
    même code couvre l'AR(1) **et** le co-krigeage collocalisé (Journel
    MM1/MM2, Xu et al. 1992). Voir `DESIGN.md` §0 et §7bis.
-2. Lire `DESIGN.md` §« Décisions ouvertes » restantes (D2 plans
-   non-emboîtés, D3 signature `fit`, D4 options par niveau, D5 nom).
-3. Puis suivre `PLAN.md` phase 0 → 5 (Phase 1 inclut désormais un oracle
+2. **D3 (signature `fit`) est tranchée : `(y, X, level)`**, `level:
+   arma::uvec` — réutilise le marshalling `(y, X)` déjà en place dans les
+   5 bindings. Voir `DESIGN.md` D3.
+3. Lire `DESIGN.md` §« Décisions ouvertes » restantes (D2 plans
+   non-emboîtés, D4 options par niveau, D5 nom).
+4. Puis suivre `PLAN.md` phase 0 → 5 (Phase 1 inclut désormais un oracle
    collocalisé en plus de `MuFiCokriging`).
 
 ## Contexte projet au moment de l'analyse

--- a/todo/REFERENCES.md
+++ b/todo/REFERENCES.md
@@ -48,6 +48,28 @@
 - **Branin 2-D** en versions fine / grossière : cohérent avec les notebooks
   démo existants du dépôt (`*_branin2d_*.ipynb` dans chaque binding).
 
+## Généralisation : co-krigeage collocalisé / Markov-model
+
+- **Journel, A.G. (1999).** *Markov models for cross-covariances.*
+  Mathematical Geology 31(8), 955–964.
+  → hypothèse de covariance croisée **proportionnelle** à une covariance
+  directe (Markov Model 1 : `C_12(h) = (B_12/B_11)·C_1(h)` ; Markov Model 2 :
+  symétrique en `C_2`). C'est la même hypothèse structurante que l'AR(1) de
+  Le Gratiet, mais **sans exiger d'ordre de fidélité** entre les deux
+  variables — seulement un plan `D_2 ⊆ D_1` (variable secondaire connue
+  partout où la primaire est échantillonnée).
+
+- **Xu, W., Tran, T.T., Srivastava, R.M. & Journel, A.G. (1992).**
+  *Integrating seismic data in reservoir modeling: the collocated
+  cokriging alternative.* SPE Annual Technical Conference.
+  → co-krigeage collocalisé : la secondaire n'intervient qu'au point cible
+  (dérive externe), simplification pratique de MM1/MM2.
+
+→ **Implication d'implémentation** : ces modèles se réduisent, comme
+l'AR(1), à un krigeage ordinaire sur un résidu / avec covariable — même
+patron de composition, aucune matrice de covariance jointe. Cf.
+`DESIGN.md` §1 et §2 (généralisation retenue) et `PLAN.md`.
+
 ## Extensions (hors scope v1, pour mémoire)
 
 - **Picheny & Ginsbourger** et la littérature co-EGO / enrichissement

--- a/todo/REFERENCES.md
+++ b/todo/REFERENCES.md
@@ -1,0 +1,63 @@
+# Références
+
+## Modèle
+
+- **Kennedy, M.C. & O'Hagan, A. (2000).** *Predicting the output from a
+  complex computer code when fast approximations are available.*
+  Biometrika 87(1), 1–13.
+  → le modèle auto-régressif AR(1) originel, formulation jointe.
+
+- **Le Gratiet, L. (2013).** *Multi-fidelity Gaussian process regression for
+  computer experiments.* Thèse, Université Paris-Diderot.
+  → **la référence à implémenter** : reformulation récursive, factorisation
+  de la vraisemblance sous plans emboîtés, formules de prédiction
+  récursives, variante bayésienne.
+
+- **Le Gratiet, L. & Garnier, J. (2014).** *Recursive co-kriging model for
+  design of computer experiments with multiple levels of fidelity.*
+  International Journal for Uncertainty Quantification 4(5), 365–386.
+  → version article, plus courte, contient les formules directement
+  exploitables.
+
+## Oracle de validation
+
+- **Package R `MuFiCokriging`** (Le Gratiet) — implémentation de référence.
+  Fonctions clés : `MuFicokm()` (fit), `predict()`, `NestedDesign()`
+  (construction de plans emboîtés).
+  ⚠ Archivé sur le CRAN — récupérer depuis les archives CRAN ou une source
+  équivalente. Fonctions utiles pour générer les références :
+  la sortie de `MuFicokm()` expose `rho`, `Beta`, `SigmA2`, `Theta` par niveau.
+
+- Cohérent avec la démarche de validation déjà en place dans le dépôt
+  contre DiceKriging (cf. `tests/references/` et
+  `bindings/R/rlibkriging/DiceKriging.md`).
+
+## Cas tests analytiques
+
+- **Forrester, A., Sóbester, A. & Keane, A. (2007).** *Multi-fidelity
+  optimization via surrogate modelling.* Proc. R. Soc. A 463, 3251–3269.
+  → le cas 1-D à deux fidélités canonique :
+
+      f_haute(x) = (6x − 2)² · sin(12x − 4)
+      f_basse(x) = 0.5 · f_haute(x) + 10(x − 0.5) − 5      x ∈ [0,1]
+
+  Idéal comme premier test : `ρ` est exactement 0.5 et le biais est linéaire,
+  donc un `ρ` constant avec tendance linéaire sur `δ` doit retrouver la
+  vérité terrain presque exactement.
+
+- **Branin 2-D** en versions fine / grossière : cohérent avec les notebooks
+  démo existants du dépôt (`*_branin2d_*.ipynb` dans chaque binding).
+
+## Extensions (hors scope v1, pour mémoire)
+
+- **Picheny & Ginsbourger** et la littérature co-EGO / enrichissement
+  multi-fidélité : « quel point, à quel niveau ? ». C'est ce que les
+  utilisateurs demanderont juste après le modèle lui-même ; l'API `update`
+  doit rester compatible avec ce cas d'usage.
+
+- **Perdikaris et al. (2017)**, *Nonlinear information fusion algorithms
+  for data-efficient multi-fidelity modelling* (NARGP) : généralisation
+  non-linéaire de la relation entre niveaux. Note d'architecture : ce serait
+  naturellement exprimable via `WarpKriging` comme sous-modèle, ce qui
+  renforce l'argument de faire du type de sous-modèle une **option** et non
+  une classe séparée.

--- a/todo/TOUCHPOINTS.md
+++ b/todo/TOUCHPOINTS.md
@@ -59,7 +59,7 @@ sont réutilisés tels quels, sans modification.
 
 | | Fichier |
 |---|---|
-| M | `bindings/Julia/jlibkriging/csrc/libkriging_c.cpp` — **le point dur** : passer une liste de matrices via l'ABI C (tableau de `double*` + tableaux de `n_t`), ou éviter le problème via la variante `level` (cf. `DESIGN.md` D3) |
+| M | `bindings/Julia/jlibkriging/csrc/libkriging_c.cpp` — signature `(y, X, level)` tranchée (D3) : réutilise le marshalling `(Vector{Float64}, Matrix{Float64})` déjà en place, `level` est un `Vector{Int32}`/`uvec` de plus, comme `nsim`/`seed` ailleurs — **plus le point dur initialement redouté** (pas de liste de matrices à passer par l'ABI C) |
 | M | `bindings/Julia/jlibkriging/src/jlibkriging.jl` |
 | C | `bindings/Julia/jlibkriging/tests/multi_fidelity_kriging_test.jl` |
 | M | `bindings/Julia/jlibkriging/CMakeLists.txt` |
@@ -104,10 +104,10 @@ ne convertit pas.
 | Cœur C++ + tests | ~4 (`Trend`/`KrigingImpl` retirés) | 1 semaine (option (b) verrouillée, pas de bascule d'option ni de risque de régression core) |
 | Python | ~7 | 3–4 j |
 | R | ~20 (dont beaucoup de `.Rd`) | 4–5 j |
-| Julia | ~5 | 3–4 j (ABI C) |
-| Octave/MATLAB | ~6 | 3–4 j (mex) |
+| Julia | ~5 | 2 j (D3 tranchée sur `level` : plus de liste de matrices à passer par l'ABI C, marshalling mécanique) |
+| Octave/MATLAB | ~6 | 2 j (idem, mex) |
 | Documentation | ~9 | 2 j |
 
-**Le poste dominant est le marshalling multi-bindings, pas les
-mathématiques.** C'est ce qui rend la décision D3 (`DESIGN.md`) — liste de
-matrices vs. vecteur `level` — la plus rentable à trancher correctement.
+**Le poste dominant reste le marshalling multi-bindings**, mais réduit par
+le verrouillage de D3 (`DESIGN.md`) sur `(y, X, level)` — plus de nouvelle
+convention de listes de matrices à inventer 5 fois.

--- a/todo/TOUCHPOINTS.md
+++ b/todo/TOUCHPOINTS.md
@@ -1,0 +1,110 @@
+# Points de contact : fichiers à créer / modifier
+
+Relevé sur l'arbre réel du dépôt. `C` = à créer, `M` = à modifier.
+Le patron à copier partout est **`NestedKriging`** (classe de composition la
+plus récente et la plus proche structurellement).
+
+## 1. Cœur C++
+
+| | Fichier | Note |
+|---|---|---|
+| C | `src/lib/include/libKriging/MultiFidelityKriging.hpp` | esquisse dans `draft/` |
+| C | `src/lib/MultiFidelityKriging.cpp` | ~600–900 l. attendues (réf. `NestedKriging.cpp` = 526 l.) |
+| M | `src/lib/CMakeLists.txt` | ajouter la paire `.cpp` / `.hpp` dans `add_library(Kriging …)` |
+| M | `src/lib/include/libKriging/Trend.hpp` + `src/lib/Trend.cpp` | **seulement si option (a)** : chemin `F` custom |
+| M | `src/lib/KrigingImpl.cpp` + `.hpp` | **seulement si option (a)** : accepter un `F` fourni |
+| M | `src/lib/KrigingLoader.cpp` / `.hpp` | seulement si `save`/`load` est dans le scope v1 |
+
+Rien d'autre dans `src/` : `Covariance`, `Optim`, `Random`, `LinearAlgebra`
+sont réutilisés tels quels.
+
+## 2. Tests C++
+
+| | Fichier |
+|---|---|
+| C | `tests/MultiFidelityKrigingTest.cpp` |
+| C | `tests/references/…` (valeurs de référence issues de `MuFiCokriging`) |
+| M | `tests/CMakeLists.txt` — copier le bloc `NestedKrigingTest` (lignes ~354-360) : `add_executable` + `target_link_libraries(… Kriging Catch2)` + `add_dependencies(all_test_binaries …)` + `catch_discover_tests` |
+
+## 3. Binding Python (pybind11 + carma) — *à faire en premier*
+
+| | Fichier |
+|---|---|
+| C | `bindings/Python/pylibkriging/src/_pylibkriging/MultiFidelityKriging_binding.cpp` |
+| C | `bindings/Python/pylibkriging/src/_pylibkriging/MultiFidelityKriging_binding.hpp` |
+| M | `bindings/Python/pylibkriging/src/_pylibkriging/pylibkriging.cpp` (enregistrement du module) |
+| M | `bindings/Python/pylibkriging/CMakeLists.txt` |
+| C | `bindings/Python/pylibkriging/tests/MultiFidelityKriging_test.py` |
+| M | `bindings/Python/pylibkriging/tests/CMakeLists.txt` |
+| C | `bindings/Python/multifidelitykriging_branin2d_py.ipynb` (notebook démo, convention du dépôt) |
+
+## 4. Binding R (Rcpp)
+
+| | Fichier |
+|---|---|
+| C | `bindings/R/rlibkriging/src/MultiFidelityKriging_binding.cpp` |
+| M | `bindings/R/rlibkriging/src/RcppExports.cpp` (régénéré par `Rcpp::compileAttributes()`) |
+| C | `bindings/R/rlibkriging/R/MultiFidelityKrigingClass.R` |
+| M | `bindings/R/rlibkriging/R/RcppExports.R` (régénéré) |
+| M | `bindings/R/rlibkriging/R/allGenerics.R` (si nouvelles génériques S3) |
+| M | `bindings/R/rlibkriging/NAMESPACE` |
+| C | `bindings/R/rlibkriging/man/*.Rd` (compter ~10-15 fichiers, cf. le volume existant pour `WarpKriging`) |
+| C | `bindings/R/rlibkriging/tests/…` |
+| C | `bindings/R/multifidelitykriging_branin2d_r.ipynb` |
+
+## 5. Binding Julia (ABI C plate — le plus pénible avec Octave)
+
+| | Fichier |
+|---|---|
+| M | `bindings/Julia/jlibkriging/csrc/libkriging_c.cpp` — **le point dur** : passer une liste de matrices via l'ABI C (tableau de `double*` + tableaux de `n_t`), ou éviter le problème via la variante `level` (cf. `DESIGN.md` D3) |
+| M | `bindings/Julia/jlibkriging/src/jlibkriging.jl` |
+| C | `bindings/Julia/jlibkriging/tests/multi_fidelity_kriging_test.jl` |
+| M | `bindings/Julia/jlibkriging/CMakeLists.txt` |
+| C | `bindings/Julia/multifidelitykriging_branin2d_julia.ipynb` |
+
+⚠ Rappel `AGENTS.md` : le FFI Julia attend exactement `Matrix{Float64}` /
+`Vector{Float64}`, aucune promotion automatique.
+
+## 6. Binding Octave / MATLAB (mex)
+
+| | Fichier |
+|---|---|
+| C | `bindings/Octave/mlibkriging/MultiFidelityKriging_binding.cpp` |
+| C | `bindings/Octave/mlibkriging/MultiFidelityKriging_binding.hpp` |
+| C | `bindings/Octave/mlibkriging/MultiFidelityKriging.m` |
+| M | `bindings/Octave/mlibkriging/mLibKriging.cpp` (dispatch) |
+| M | `bindings/Octave/mlibkriging/CMakeLists.txt` |
+| C | `bindings/Octave/mlibkriging/tests/MultiFidelityKriging_test.m` |
+
+⚠ Rappel `AGENTS.md` : les arguments entiers (`nsim`, `seed`, et ici
+potentiellement `level`) doivent être passés en `int32(...)` ; la couche mex
+ne convertit pas.
+
+## 7. Documentation
+
+| | Fichier |
+|---|---|
+| M | `skills/libkriging/SKILL.md` — nouvelle branche §1 de l'arbre de décision : « plusieurs niveaux de fidélité ? » ; nouvelle section options `rho` / niveaux |
+| M | `skills/libkriging/references/cpp.md` |
+| M | `skills/libkriging/references/python.md` |
+| M | `skills/libkriging/references/r.md` |
+| M | `skills/libkriging/references/julia.md` |
+| M | `skills/libkriging/references/octave-matlab.md` |
+| M | `CHANGELOG.md` |
+| M | `AGENTS.md` — ajouter `MultiFidelityKriging` à la liste des classes de la section « API usage guidance » |
+| M | `bindings/R/rlibkriging/DiceKriging.md` — table de correspondance, si pertinent vis-à-vis de `MuFiCokriging` |
+
+## 8. Récapitulatif de l'effort
+
+| Poste | Fichiers | Estimation |
+|---|---|---|
+| Cœur C++ + tests | ~5 | 1–2 semaines |
+| Python | ~7 | 3–4 j |
+| R | ~20 (dont beaucoup de `.Rd`) | 4–5 j |
+| Julia | ~5 | 3–4 j (ABI C) |
+| Octave/MATLAB | ~6 | 3–4 j (mex) |
+| Documentation | ~9 | 2 j |
+
+**Le poste dominant est le marshalling multi-bindings, pas les
+mathématiques.** C'est ce qui rend la décision D3 (`DESIGN.md`) — liste de
+matrices vs. vecteur `level` — la plus rentable à trancher correctement.

--- a/todo/TOUCHPOINTS.md
+++ b/todo/TOUCHPOINTS.md
@@ -8,21 +8,24 @@ plus récente et la plus proche structurellement).
 
 | | Fichier | Note |
 |---|---|---|
-| C | `src/lib/include/libKriging/MultiFidelityKriging.hpp` | esquisse dans `draft/` |
-| C | `src/lib/MultiFidelityKriging.cpp` | ~600–900 l. attendues (réf. `NestedKriging.cpp` = 526 l.) |
-| M | `src/lib/CMakeLists.txt` | ajouter la paire `.cpp` / `.hpp` dans `add_library(Kriging …)` |
-| M | `src/lib/include/libKriging/Trend.hpp` + `src/lib/Trend.cpp` | **seulement si option (a)** : chemin `F` custom |
-| M | `src/lib/KrigingImpl.cpp` + `.hpp` | **seulement si option (a)** : accepter un `F` fourni |
+| C | `src/lib/include/libKriging/MarkovCoKriging.hpp` | esquisse dans `draft/` |
+| C | `src/lib/MarkovCoKriging.cpp` | ~600–900 l. attendues (réf. `NestedKriging.cpp` = 526 l.) ; couvre AR(1) **et** collocalisé (même classe, cf. `DESIGN.md` §0/§7bis) |
+| M | `src/lib/CMakeLists.txt` | ajouter la paire `.cpp` / `.hpp` + lien vers `lbfgsb_cpp` (déjà vendorisé, cf. §7bis) |
 | M | `src/lib/KrigingLoader.cpp` / `.hpp` | seulement si `save`/`load` est dans le scope v1 |
 
+~~`Trend.hpp/.cpp` (chemin `F` custom)~~ et ~~`KrigingImpl.cpp/.hpp`
+(accepter un `F` fourni)~~ : **retirés du scope** — D1 verrouillée sur
+l'option (b), aucune modification du core requise (`DESIGN.md` §6 D1,
+§7bis).
+
 Rien d'autre dans `src/` : `Covariance`, `Optim`, `Random`, `LinearAlgebra`
-sont réutilisés tels quels.
+sont réutilisés tels quels, sans modification.
 
 ## 2. Tests C++
 
 | | Fichier |
 |---|---|
-| C | `tests/MultiFidelityKrigingTest.cpp` |
+| C | `tests/MarkovCoKrigingTest.cpp` |
 | C | `tests/references/…` (valeurs de référence issues de `MuFiCokriging`) |
 | M | `tests/CMakeLists.txt` — copier le bloc `NestedKrigingTest` (lignes ~354-360) : `add_executable` + `target_link_libraries(… Kriging Catch2)` + `add_dependencies(all_test_binaries …)` + `catch_discover_tests` |
 
@@ -30,27 +33,27 @@ sont réutilisés tels quels.
 
 | | Fichier |
 |---|---|
-| C | `bindings/Python/pylibkriging/src/_pylibkriging/MultiFidelityKriging_binding.cpp` |
-| C | `bindings/Python/pylibkriging/src/_pylibkriging/MultiFidelityKriging_binding.hpp` |
+| C | `bindings/Python/pylibkriging/src/_pylibkriging/MarkovCoKriging_binding.cpp` |
+| C | `bindings/Python/pylibkriging/src/_pylibkriging/MarkovCoKriging_binding.hpp` |
 | M | `bindings/Python/pylibkriging/src/_pylibkriging/pylibkriging.cpp` (enregistrement du module) |
 | M | `bindings/Python/pylibkriging/CMakeLists.txt` |
-| C | `bindings/Python/pylibkriging/tests/MultiFidelityKriging_test.py` |
+| C | `bindings/Python/pylibkriging/tests/MarkovCoKriging_test.py` |
 | M | `bindings/Python/pylibkriging/tests/CMakeLists.txt` |
-| C | `bindings/Python/multifidelitykriging_branin2d_py.ipynb` (notebook démo, convention du dépôt) |
+| C | `bindings/Python/markovcokriging_branin2d_py.ipynb` (notebook démo, convention du dépôt) |
 
 ## 4. Binding R (Rcpp)
 
 | | Fichier |
 |---|---|
-| C | `bindings/R/rlibkriging/src/MultiFidelityKriging_binding.cpp` |
+| C | `bindings/R/rlibkriging/src/MarkovCoKriging_binding.cpp` |
 | M | `bindings/R/rlibkriging/src/RcppExports.cpp` (régénéré par `Rcpp::compileAttributes()`) |
-| C | `bindings/R/rlibkriging/R/MultiFidelityKrigingClass.R` |
+| C | `bindings/R/rlibkriging/R/MarkovCoKrigingClass.R` |
 | M | `bindings/R/rlibkriging/R/RcppExports.R` (régénéré) |
 | M | `bindings/R/rlibkriging/R/allGenerics.R` (si nouvelles génériques S3) |
 | M | `bindings/R/rlibkriging/NAMESPACE` |
 | C | `bindings/R/rlibkriging/man/*.Rd` (compter ~10-15 fichiers, cf. le volume existant pour `WarpKriging`) |
 | C | `bindings/R/rlibkriging/tests/…` |
-| C | `bindings/R/multifidelitykriging_branin2d_r.ipynb` |
+| C | `bindings/R/markovcokriging_branin2d_r.ipynb` |
 
 ## 5. Binding Julia (ABI C plate — le plus pénible avec Octave)
 
@@ -60,7 +63,7 @@ sont réutilisés tels quels.
 | M | `bindings/Julia/jlibkriging/src/jlibkriging.jl` |
 | C | `bindings/Julia/jlibkriging/tests/multi_fidelity_kriging_test.jl` |
 | M | `bindings/Julia/jlibkriging/CMakeLists.txt` |
-| C | `bindings/Julia/multifidelitykriging_branin2d_julia.ipynb` |
+| C | `bindings/Julia/markovcokriging_branin2d_julia.ipynb` |
 
 ⚠ Rappel `AGENTS.md` : le FFI Julia attend exactement `Matrix{Float64}` /
 `Vector{Float64}`, aucune promotion automatique.
@@ -69,12 +72,12 @@ sont réutilisés tels quels.
 
 | | Fichier |
 |---|---|
-| C | `bindings/Octave/mlibkriging/MultiFidelityKriging_binding.cpp` |
-| C | `bindings/Octave/mlibkriging/MultiFidelityKriging_binding.hpp` |
-| C | `bindings/Octave/mlibkriging/MultiFidelityKriging.m` |
+| C | `bindings/Octave/mlibkriging/MarkovCoKriging_binding.cpp` |
+| C | `bindings/Octave/mlibkriging/MarkovCoKriging_binding.hpp` |
+| C | `bindings/Octave/mlibkriging/MarkovCoKriging.m` |
 | M | `bindings/Octave/mlibkriging/mLibKriging.cpp` (dispatch) |
 | M | `bindings/Octave/mlibkriging/CMakeLists.txt` |
-| C | `bindings/Octave/mlibkriging/tests/MultiFidelityKriging_test.m` |
+| C | `bindings/Octave/mlibkriging/tests/MarkovCoKriging_test.m` |
 
 ⚠ Rappel `AGENTS.md` : les arguments entiers (`nsim`, `seed`, et ici
 potentiellement `level`) doivent être passés en `int32(...)` ; la couche mex
@@ -91,14 +94,14 @@ ne convertit pas.
 | M | `skills/libkriging/references/julia.md` |
 | M | `skills/libkriging/references/octave-matlab.md` |
 | M | `CHANGELOG.md` |
-| M | `AGENTS.md` — ajouter `MultiFidelityKriging` à la liste des classes de la section « API usage guidance » |
+| M | `AGENTS.md` — ajouter `MarkovCoKriging` à la liste des classes de la section « API usage guidance » |
 | M | `bindings/R/rlibkriging/DiceKriging.md` — table de correspondance, si pertinent vis-à-vis de `MuFiCokriging` |
 
 ## 8. Récapitulatif de l'effort
 
 | Poste | Fichiers | Estimation |
 |---|---|---|
-| Cœur C++ + tests | ~5 | 1–2 semaines |
+| Cœur C++ + tests | ~4 (`Trend`/`KrigingImpl` retirés) | 1 semaine (option (b) verrouillée, pas de bascule d'option ni de risque de régression core) |
 | Python | ~7 | 3–4 j |
 | R | ~20 (dont beaucoup de `.Rd`) | 4–5 j |
 | Julia | ~5 | 3–4 j (ABI C) |

--- a/todo/draft/MarkovCoKriging.hpp
+++ b/todo/draft/MarkovCoKriging.hpp
@@ -4,20 +4,20 @@
 // Vérifiée syntaxiquement contre les vrais en-têtes du dépôt :
 //   g++ -fsyntax-only -std=c++17 -Isrc/lib/include -Ibuild/src/lib \
 //       -Idependencies/armadillo-code/include -x c++ \
-//       wip2/draft/MultiFidelityKriging.hpp
+//       todo/draft/MarkovCoKriging.hpp
 // (nécessite un `build/` déjà configuré, pour libKriging_exports.h généré).
 //
-// Brouillon d'API pour MultiFidelityKriging, calqué sur la structure de
+// Brouillon d'API pour MarkovCoKriging, calqué sur la structure de
 // src/lib/include/libKriging/NestedKriging.hpp (classe de composition sur un
 // vecteur de sous-Kriging).
 //
 // À déplacer vers src/lib/include/libKriging/ une fois les décisions D1-D5 de
-// wip2/DESIGN.md tranchées. Les points marqués « D? » dépendent directement
+// todo/DESIGN.md tranchées. Les points marqués « D? » dépendent directement
 // d'un arbitrage encore ouvert.
 // =============================================================================
 
-#ifndef LIBKRIGING_MULTIFIDELITYKRIGING_HPP
-#define LIBKRIGING_MULTIFIDELITYKRIGING_HPP
+#ifndef LIBKRIGING_MARKOVCOKRIGING_HPP
+#define LIBKRIGING_MARKOVCOKRIGING_HPP
 
 #include <memory>
 #include <string>
@@ -31,32 +31,42 @@
 #include "libKriging/Trend.hpp"
 #include "libKriging/libKriging_exports.h"
 
-/** Multi-fidelity Kriging: recursive AR(1) co-kriging (Le Gratiet, 2013).
+/** Markov-type co-kriging: recursive proportional-covariance co-kriging
+ * (Journel 1999, MM1/MM2). Two instances share this exact class:
+ *   - AR(1) multi-fidelity (Le Gratiet, 2013): s>=2 levels ordered by cost,
+ *     nested designs D_s subset ... subset D_1;
+ *   - collocated co-kriging (Xu et al., 1992): s=2, no cost/fidelity order,
+ *     level 0 = secondary field, level 1 = primary, same nesting requirement.
  *
- * s fidelity levels, t=1 the cheapest/least accurate, t=s the reference code:
+ * s levels, t=0 the "parent" field (cheapest, or the secondary variable),
+ * t=s-1 the field of interest:
  *
- *   Z_1(x) ~ GP(f_1(x)' b_1, s_1^2 r_1(.,.;th_1))
+ *   Z_0(x) ~ GP(f_0(x)' b_0, s_0^2 r_0(.,.;th_0))
  *   Z_t(x) = rho_{t-1}(x) Z_{t-1}(x) + d_t(x),  d_t independent of Z_{t-1}
  *
- * Under NESTED designs D_s subset ... subset D_1, the joint likelihood
- * factorizes into s independent likelihoods, so the fit reduces to s ordinary
- * Kriging fits on residuals: O(sum n_t^3) instead of O((sum n_t)^3).
+ * Under NESTED designs, the joint likelihood factorizes into s independent
+ * likelihoods, so the fit reduces to s ordinary Kriging fits on residuals:
+ * O(sum n_t^3) instead of O((sum n_t)^3).
  *
- * rho is estimated as a trend coefficient by augmenting the level-t regression
- * matrix with y_{t-1}(D_t) * g(x) columns (option (a) of DESIGN.md), or by an
- * outer profiling loop (option (b)).
+ * rho is estimated by an OUTER PROFILING LOOP around unmodified Kriging fits
+ * (option (b) of DESIGN.md, locked in permanently, cf. §6 D1 / §7bis): for
+ * each candidate rho, fit an ordinary Kriging on
+ * z_t = y_t - rho(D_t) * y_{t-1}(D_t) and read its concentrated LL; rho
+ * maximizes it. No custom regression matrix, no change to KrigingImpl/Trend.
  *
  * Prediction is recursive:
  *   mu_t(x)  = rho_{t-1}(x) mu_{t-1}(x) + mu_{d_t}(x)
  *   var_t(x) = rho_{t-1}(x)^2 var_{t-1}(x) + var_{d_t}(x)
  *
  * Restrictions to enforce and document:
- *   - nested designs required (D2: strict, or opt-in approximation);
+ *   - nested designs required (D2: strict, or opt-in approximation using the
+ *     parent's predicted mean instead of its observed value);
  *   - `normalize` must be global, never per level;
- *   - level ordering: index 0 == LOWEST fidelity (classic source of mistakes);
+ *   - level ordering: index 0 == PARENT field (lowest fidelity, or the
+ *     collocated secondary variable) -- classic source of mistakes;
  *   - s >= 2.
  */
-class MultiFidelityKriging {
+class MarkovCoKriging {
  public:
   /// Form of the scaling factor rho between consecutive levels.
   enum class RhoModel {
@@ -67,9 +77,9 @@ class MultiFidelityKriging {
   LIBKRIGING_EXPORT static RhoModel rhoModelFromString(const std::string& s);
   LIBKRIGING_EXPORT static std::string rhoModelToString(RhoModel m);
 
-  MultiFidelityKriging() = delete;
+  MarkovCoKriging() = delete;
 
-  LIBKRIGING_EXPORT explicit MultiFidelityKriging(const std::string& covType);
+  LIBKRIGING_EXPORT explicit MarkovCoKriging(const std::string& covType);
 
   // ---------------------------------------------------------------------------
   // D3 (OPEN): two candidate signatures for fit. Pick ONE before writing the
@@ -170,8 +180,10 @@ class MultiFidelityKriging {
   [[nodiscard]] arma::uvec nested_indices(arma::uword t) const;
   /// rho_t evaluated at the rows of X_n (q-vector).
   [[nodiscard]] arma::vec eval_rho(arma::uword t, const arma::mat& X_n) const;
-  /// Augmented regression matrix [ diag(y_{t-1}(D_t)) G | F ] -- option (a) only.
-  [[nodiscard]] arma::mat augmented_trend_matrix(arma::uword t) const;
+  /// Outer profiling of rho_t via lbfgsb_cpp (already vendored/linked, cf.
+  /// DESIGN.md §7bis): fits a Kriging on the residual for each candidate rho
+  /// and returns the one maximizing its concentrated log-likelihood.
+  [[nodiscard]] arma::vec fit_rho(arma::uword t) const;
 };
 
-#endif  // LIBKRIGING_MULTIFIDELITYKRIGING_HPP
+#endif  // LIBKRIGING_MARKOVCOKRIGING_HPP

--- a/todo/draft/MarkovCoKriging.hpp
+++ b/todo/draft/MarkovCoKriging.hpp
@@ -82,32 +82,16 @@ class MarkovCoKriging {
   LIBKRIGING_EXPORT explicit MarkovCoKriging(const std::string& covType);
 
   // ---------------------------------------------------------------------------
-  // D3 (OPEN): two candidate signatures for fit. Pick ONE before writing the
-  // bindings -- this is the single most expensive decision of the project.
-  //
-  //   Variant A: list-of-levels. Natural, but a brand-new marshalling
-  //   convention must be written for all 5 bindings (painful in the Julia flat
-  //   C ABI and the Octave mex layer).
-  //
-  //   Variant B: flat data + level index vector. Reuses the existing (y, X)
-  //   marshalling everywhere, at the cost of a slightly less natural API and an
-  //   internal split. Likely halves the binding cost.
-  //
-  // Both are sketched below; delete the loser.
+  // D3 (TRANCHÉE): flat data + level index vector. Reuses the existing (y, X)
+  // marshalling everywhere -- no new convention needed in any of the 5
+  // bindings, unlike the list-of-levels alternative (discarded: it would have
+  // required inventing a new marshalling convention in all 5 bindings,
+  // painful in particular in the Julia flat C ABI and the Octave mex layer).
   // ---------------------------------------------------------------------------
 
-  /// Variant A -- y[t] is n_t, X[t] is n_t x d ; index 0 == lowest fidelity.
-  LIBKRIGING_EXPORT void fit(const std::vector<arma::vec>& y,
-                             const std::vector<arma::mat>& X,
-                             RhoModel rho_model = RhoModel::Constant,
-                             const Trend::RegressionModel& regmodel = Trend::RegressionModel::Constant,
-                             bool normalize = false,
-                             const std::string& optim = "BFGS",
-                             const std::string& objective = "LL",
-                             const std::vector<Kriging::Parameters>& parameters = {});
-
-  /// Variant B -- y is n, X is n x d, level is n with values in [0, s-1];
-  /// level 0 == lowest fidelity.
+  /// y is n, X is n x d, level is n with values in [0, s-1];
+  /// level 0 == parent field (lowest fidelity, or the collocated secondary
+  /// variable). Chain topology assumed: parent(t) = t-1.
   LIBKRIGING_EXPORT void fit(const arma::vec& y,
                              const arma::mat& X,
                              const arma::uvec& level,

--- a/todo/draft/MultiFidelityKriging.hpp
+++ b/todo/draft/MultiFidelityKriging.hpp
@@ -1,0 +1,177 @@
+// =============================================================================
+// ESQUISSE — NON BRANCHÉE AU BUILD (aucune implémentation .cpp).
+//
+// Vérifiée syntaxiquement contre les vrais en-têtes du dépôt :
+//   g++ -fsyntax-only -std=c++17 -Isrc/lib/include -Ibuild/src/lib \
+//       -Idependencies/armadillo-code/include -x c++ \
+//       wip2/draft/MultiFidelityKriging.hpp
+// (nécessite un `build/` déjà configuré, pour libKriging_exports.h généré).
+//
+// Brouillon d'API pour MultiFidelityKriging, calqué sur la structure de
+// src/lib/include/libKriging/NestedKriging.hpp (classe de composition sur un
+// vecteur de sous-Kriging).
+//
+// À déplacer vers src/lib/include/libKriging/ une fois les décisions D1-D5 de
+// wip2/DESIGN.md tranchées. Les points marqués « D? » dépendent directement
+// d'un arbitrage encore ouvert.
+// =============================================================================
+
+#ifndef LIBKRIGING_MULTIFIDELITYKRIGING_HPP
+#define LIBKRIGING_MULTIFIDELITYKRIGING_HPP
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "libKriging/utils/lk_armadillo.hpp"
+
+#include "libKriging/Covariance.hpp"
+#include "libKriging/Kriging.hpp"
+#include "libKriging/Trend.hpp"
+#include "libKriging/libKriging_exports.h"
+
+/** Multi-fidelity Kriging: recursive AR(1) co-kriging (Le Gratiet, 2013).
+ *
+ * s fidelity levels, t=1 the cheapest/least accurate, t=s the reference code:
+ *
+ *   Z_1(x) ~ GP(f_1(x)' b_1, s_1^2 r_1(.,.;th_1))
+ *   Z_t(x) = rho_{t-1}(x) Z_{t-1}(x) + d_t(x),  d_t independent of Z_{t-1}
+ *
+ * Under NESTED designs D_s subset ... subset D_1, the joint likelihood
+ * factorizes into s independent likelihoods, so the fit reduces to s ordinary
+ * Kriging fits on residuals: O(sum n_t^3) instead of O((sum n_t)^3).
+ *
+ * rho is estimated as a trend coefficient by augmenting the level-t regression
+ * matrix with y_{t-1}(D_t) * g(x) columns (option (a) of DESIGN.md), or by an
+ * outer profiling loop (option (b)).
+ *
+ * Prediction is recursive:
+ *   mu_t(x)  = rho_{t-1}(x) mu_{t-1}(x) + mu_{d_t}(x)
+ *   var_t(x) = rho_{t-1}(x)^2 var_{t-1}(x) + var_{d_t}(x)
+ *
+ * Restrictions to enforce and document:
+ *   - nested designs required (D2: strict, or opt-in approximation);
+ *   - `normalize` must be global, never per level;
+ *   - level ordering: index 0 == LOWEST fidelity (classic source of mistakes);
+ *   - s >= 2.
+ */
+class MultiFidelityKriging {
+ public:
+  /// Form of the scaling factor rho between consecutive levels.
+  enum class RhoModel {
+    Constant,  ///< rho(x) = rho_0                       (default)
+    Linear,    ///< rho(x) = rho_0 + sum_k rho_k x_k
+  };
+
+  LIBKRIGING_EXPORT static RhoModel rhoModelFromString(const std::string& s);
+  LIBKRIGING_EXPORT static std::string rhoModelToString(RhoModel m);
+
+  MultiFidelityKriging() = delete;
+
+  LIBKRIGING_EXPORT explicit MultiFidelityKriging(const std::string& covType);
+
+  // ---------------------------------------------------------------------------
+  // D3 (OPEN): two candidate signatures for fit. Pick ONE before writing the
+  // bindings -- this is the single most expensive decision of the project.
+  //
+  //   Variant A: list-of-levels. Natural, but a brand-new marshalling
+  //   convention must be written for all 5 bindings (painful in the Julia flat
+  //   C ABI and the Octave mex layer).
+  //
+  //   Variant B: flat data + level index vector. Reuses the existing (y, X)
+  //   marshalling everywhere, at the cost of a slightly less natural API and an
+  //   internal split. Likely halves the binding cost.
+  //
+  // Both are sketched below; delete the loser.
+  // ---------------------------------------------------------------------------
+
+  /// Variant A -- y[t] is n_t, X[t] is n_t x d ; index 0 == lowest fidelity.
+  LIBKRIGING_EXPORT void fit(const std::vector<arma::vec>& y,
+                             const std::vector<arma::mat>& X,
+                             RhoModel rho_model = RhoModel::Constant,
+                             const Trend::RegressionModel& regmodel = Trend::RegressionModel::Constant,
+                             bool normalize = false,
+                             const std::string& optim = "BFGS",
+                             const std::string& objective = "LL",
+                             const std::vector<Kriging::Parameters>& parameters = {});
+
+  /// Variant B -- y is n, X is n x d, level is n with values in [0, s-1];
+  /// level 0 == lowest fidelity.
+  LIBKRIGING_EXPORT void fit(const arma::vec& y,
+                             const arma::mat& X,
+                             const arma::uvec& level,
+                             RhoModel rho_model = RhoModel::Constant,
+                             const Trend::RegressionModel& regmodel = Trend::RegressionModel::Constant,
+                             bool normalize = false,
+                             const std::string& optim = "BFGS",
+                             const std::string& objective = "LL",
+                             const std::vector<Kriging::Parameters>& parameters = {});
+
+  /** Recursive prediction at the highest fidelity level.
+   * @return (mean [q], stdev [q]) ; stdev empty if return_stdev=false. */
+  LIBKRIGING_EXPORT std::tuple<arma::vec, arma::vec> predict(const arma::mat& X_n, bool return_stdev = true);
+
+  /** Recursive prediction at an arbitrary level (0-based, 0 == lowest). */
+  LIBKRIGING_EXPORT std::tuple<arma::vec, arma::vec> predict(const arma::mat& X_n,
+                                                             arma::uword level,
+                                                             bool return_stdev = true);
+
+  /** Joint recursive simulation: simulate Z_1, then compose
+   * Z_t = rho_{t-1} * Z_{t-1} + d_t with the seed propagated PATH BY PATH
+   * (required for jointly consistent trajectories).
+   * @return q x nsim matrix at the highest fidelity level. */
+  LIBKRIGING_EXPORT arma::mat simulate(int nsim, int seed, const arma::mat& X_n);
+
+  /** Add observations at ONE fidelity level.
+   * Levels below `level` are untouched; `level` is updated; levels above are
+   * refitted (nesting and the y_{t-1}(D_t) column may both have changed). */
+  LIBKRIGING_EXPORT void update(const arma::vec& y_u, const arma::mat& X_u, arma::uword level, bool refit = true);
+
+  /// Sum of the per-level log-likelihoods (exact joint LL under nested designs).
+  LIBKRIGING_EXPORT double logLikelihood();
+
+  LIBKRIGING_EXPORT std::string summary() const;
+
+  // --- accessors -------------------------------------------------------------
+  [[nodiscard]] const std::string& kernel() const { return m_covType; }
+  [[nodiscard]] arma::uword nb_levels() const { return m_submodels.size(); }
+  [[nodiscard]] RhoModel rho_model() const { return m_rho_model; }
+  /// Estimated rho coefficients between level t and t+1 (size nb_levels()-1).
+  [[nodiscard]] const std::vector<arma::vec>& rho() const { return m_rho; }
+  /// Per-level residual submodel (level 0 models Z_1 itself, level t>0 models d_t).
+  [[nodiscard]] LIBKRIGING_EXPORT const Kriging& submodel(arma::uword t) const;
+
+ private:
+  // configuration
+  std::string m_covType;
+  RhoModel m_rho_model = RhoModel::Constant;
+  Trend::RegressionModel m_regmodel = Trend::RegressionModel::Constant;
+  bool m_normalize = false;
+
+  // data, per level (index 0 == lowest fidelity)
+  std::vector<arma::mat> m_X;
+  std::vector<arma::vec> m_y;
+
+  // submodels: m_submodels[0] models Z_1, m_submodels[t>0] models delta_t
+  std::vector<std::unique_ptr<Kriging>> m_submodels;
+
+  /// rho coefficients, m_rho[t] links level t to level t+1 (size s-1).
+  /// Length of each entry: 1 for Constant, d+1 for Linear.
+  std::vector<arma::vec> m_rho;
+
+  bool m_is_fitted = false;
+
+  // helpers
+  /// Throw unless D_s subset ... subset D_1 (D2: unless the approximate mode
+  /// has been explicitly enabled).
+  void check_nested_designs() const;
+  /// Row indices of D_t inside D_{t-1}.
+  [[nodiscard]] arma::uvec nested_indices(arma::uword t) const;
+  /// rho_t evaluated at the rows of X_n (q-vector).
+  [[nodiscard]] arma::vec eval_rho(arma::uword t, const arma::mat& X_n) const;
+  /// Augmented regression matrix [ diag(y_{t-1}(D_t)) G | F ] -- option (a) only.
+  [[nodiscard]] arma::mat augmented_trend_matrix(arma::uword t) const;
+};
+
+#endif  // LIBKRIGING_MULTIFIDELITYKRIGING_HPP


### PR DESCRIPTION
## Résumé

Dossier de conception (`todo/`) pour l'implémentation d'un co-krigeage de type Markov dans libKriging, couvrant deux cas d'usage avec le même code :

- **AR(1) multi-fidélité** (Le Gratiet, 2013) : plusieurs niveaux de fidélité, plans emboîtés, récursion `Z_t = ρ_{t-1}·Z_{t-1} + δ_t`.
- **Co-krigeage collocalisé** (Xu et al., 1992) : variable secondaire/primaire sans ordre de fidélité, même contrainte structurale de plan emboîté.

Les deux sont des instances du co-krigeage de type Markov (Journel, 1999 — covariance croisée proportionnelle à une covariance directe), d'où le partage de code.

**Aucun code source n'est modifié** : ce PR n'ajoute que le dossier d'analyse/conception (`todo/`), rien dans `src/`, `bindings/`, `tests/` ou `skills/`.

## Décision clé

Le traitement de `ρ` est verrouillé sur un profilage externe (boucle d'optimisation via `lbfgsb_cpp`, déjà vendorisé) autour de `Kriging::fit` standard sur les résidus — **zéro modification de `KrigingImpl`/`Trend`**, donc zéro risque de régression sur `Kriging`/`WarpKriging`/`MLPKriging`/`NestedKriging`.

## Contenu de `todo/`

| Fichier | Rôle |
|---|---|
| `README.md` | Point d'entrée, reprise rapide |
| `ANALYSIS.md` | Analyse initiale : effort, séquencement |
| `DESIGN.md` | Formulation mathématique + décisions D1-D5 (D1 et D3 tranchées) |
| `TOUCHPOINTS.md` | Fichiers à créer/modifier (core, 5 bindings, tests, doc) |
| `PLAN.md` | Checklist séquencée par phase, critères de sortie |
| `REFERENCES.md` | Bibliographie et oracles de validation (`MuFiCokriging`, `gstat`) |
| `draft/MarkovCoKriging.hpp` | Esquisse d'API C++, vérifiée syntaxiquement, non branchée au build |

## Décisions ouvertes restantes

- D2 : traitement des plans non-emboîtés (refus strict proposé pour v1)
- D4 : options par niveau (kernel/regmodel/optim/noise), scalaire ou vecteur
- D5 : nom de classe quasi tranché (`MarkovCoKriging`)

## Test plan

- [ ] Aucun changement de code source — `ctest` inchangé par construction
- [ ] Relecture du dossier de conception par un mainteneur avant démarrage de la Phase 1 (oracles de validation)