### PR TITLE
Fix undefined PROCESSOR_COUNT causing flaky Coverage-mode CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,8 +663,28 @@ include(CTest)
 add_subdirectory(tests)
 add_subdirectory(bench)
 
+# PROCESSOR_COUNT was previously used below without ever being set, silently
+# expanding to nothing and letting `ctest -j` fall back to CTest's own
+# "use every detected core" default -- full, unconstrained parallelism with no
+# --output-on-failure, unlike every other ctest invocation in this project
+# (tools/*/test.sh run ctest serially). On shared/resource-constrained CI
+# runners this oversubscribes (each test binary may itself spawn OpenMP
+# threads) and made tolerance/timing-sensitive tests (BFGS-within-budget,
+# gradient-vs-finite-differences, concurrent-access stress tests) intermittently
+# fail under contention -- reproduced identically across unrelated branches and
+# unrelated content changes. Detect a real core count (falling back to 1 if
+# detection fails) and cap it modestly.
+include(ProcessorCount)
+ProcessorCount(PROCESSOR_COUNT)
+if (PROCESSOR_COUNT EQUAL 0)
+    set(PROCESSOR_COUNT 1)
+endif ()
+if (PROCESSOR_COUNT GREATER 4)
+    set(PROCESSOR_COUNT 4)
+endif ()
+
 add_custom_target(run_unit_tests
-        COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT}
+        COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT} --output-on-failure
         COMMENT "Executing unit tests."
         DEPENDS all_test_binaries
         )
@@ -697,7 +717,7 @@ if (ENABLE_COVERAGE)
             # This way the percentage of total lines covered will always be correct, even when not all source code files were loaded during the test(s)
             COMMAND ${LCOV} --base-directory ${LIBKRIGING_SOURCE_DIR} --directory ${LIBKRIGING_BINARY_DIR} --capture --initial --output-file coverage_base.info
             # Run tests
-            COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT}
+            COMMAND ${CMAKE_CTEST_COMMAND} -j ${PROCESSOR_COUNT} --output-on-failure
             # Collect data from executions
             COMMAND ${LCOV} --base-directory ${LIBKRIGING_SOURCE_DIR} --directory ${LIBKRIGING_BINARY_DIR} --capture --output-file coverage_ctest.info
             # Combine base and ctest results


### PR DESCRIPTION
## Summary
- `PROCESSOR_COUNT` was used in two `ctest -j` invocations (`run_unit_tests` and the `coverage` custom target) without ever being defined anywhere in the project — it silently expanded to nothing, letting `ctest -j` fall back to CTest's "use every detected core" default. Every other test-running path in the repo (`tools/*/test.sh`'s normal branch used by "Build and tests", ASan, TSan, Memcheck) runs `ctest` serially (no `-j` at all).
- On a shared/resource-constrained CI runner, this ran the full test suite with unconstrained parallelism (each test binary can itself spawn OpenMP threads, so this oversubscribes) on top of a `Debug` + `-g --coverage` (unoptimized, `gcov`-instrumented, already-slower) build — with no `--output-on-failure` for diagnosability.
- Under that contention, tolerance/timing-sensitive tests (`BFGS finds better than grid search` within an iteration budget, `gradient vs finite differences` comparisons, and an explicit `LinearAlgebra concurrent access` stress test now double-stacked with ctest-level parallelism on top) intermittently miss their margins.

## Evidence this is pre-existing/structural, not tied to any one PR
- The same "Coverage mode" CI job failed identically on `feature/cg-predict` on two separate runs 40 minutes apart with the *same* content, and again independently on `feature/nystrom-vecchia-subset` (#358) on a push containing zero C++ changes.
- Several of the *exact same test names* failed across these otherwise-unrelated runs/branches — `KrigingFitTest - BFGS finds better LL/LOO/LMP than grid search`, `KrigingUpdateTest - Updated model equals combined fit`, `KrigingPredictTest - Check gradient vs finite differences with normalize=true`.

## Fix
Detect a real core count via CMake's `ProcessorCount` module (falling back to 1 if detection fails), cap it at 4 to keep oversubscription risk in check, and add `--output-on-failure` to both `ctest` invocations so a genuine future failure is actually diagnosable from the CI log.

## Test plan
- [x] Locally verified the generated build rule: `ctest -j 4 --output-on-failure` (correctly capped and diagnosable) instead of the previous bare `ctest -j` (undefined variable).
- [x] `lcov` isn't available in this sandbox to run the `coverage` target itself, but the fix is a 2-line mechanical change identical in both invocation sites; the `run_unit_tests` target (same code path) was verified directly.

https://claude.ai/code/session_019JFYXJMDzGAoCqpyRa6oNx